### PR TITLE
Monitor Webrtc track use non-UUID format

### DIFF
--- a/src/Sampler.ts
+++ b/src/Sampler.ts
@@ -393,8 +393,8 @@ export class Sampler {
             const remoteInboundRtpStats = outboundRtp.getRemoteInboundRtp()?.stats || {};
             const mediaSource = outboundRtp.getMediaSource();
             const trackId = outboundRtp.getTrackId();
-            if (!trackId || !isValidUuid(trackId)) {
-                logger.debug(`TrackId ${trackId} either not a uuid or does not exist`);
+            if (!trackId) {
+                logger.debug(`TrackId ${trackId}  does not exist`);
                 continue;
             }
             if (outboundRtp.stats.kind === "audio") {
@@ -453,8 +453,8 @@ export class Sampler {
                 continue;
             }
             const trackId = inboundRtp.getTrackId();
-            if (!trackId || !isValidUuid(trackId)) {
-                logger.debug(`TrackId ${trackId} either not a uuid or not exists`);
+            if (!trackId) {
+                logger.debug(`TrackId ${trackId} not exists`);
                 continue;
             }
             const remoteOutboundRtpStats = inboundRtp.getRemoteOutboundRtp()?.stats || {};


### PR DESCRIPTION
There are Webrtc track ID use non-UUID format. Check ID as valid UUID stop application use it