### PR TITLE
4.8.0 — sample schema 3.7.0, transport observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 4.8.0
+
+Transport observability. Three themes: **the RTP → transport → candidate-pair graph is fully traversable and attributed by one rule**, **DTLS handshake failure finally has an owner**, and **samples stop repeating constants** (sample schema **3.7.0**).
+
+### Wire / payload changes — schema `ClientSample` 3.7.0
+
+-   **Payloads may nest.** `ClientEvent.payload`, `ClientIssue.payload`, `ClientMetaData.payload` and `ExtensionStat.payload` accept nested structures (`Record<string, unknown>`), not only flat records of primitives — still records on the wire, never pre-serialised JSON strings. `ClientPayload` widened accordingly; `ClientPayloadValue` is removed (it named the flat-only constraint).
+-   **`PEER_CONNECTION_ICE_PATH_CHANGED` carries structured `from`/`to`.** The path evidence travels as records now that the schema allows nesting; before 3.7.0 the two fields were JSON documents in strings. Consumers parsing them with `JSON.parse` must read them as objects instead.
+-   **`IceTransportStats` static members ship on change only.** `iceRole`, `iceLocalUsernameFragment`, `localCertificateId`, `remoteCertificateId`, `tlsVersion`, `dtlsCipher`, `dtlsRole` and `srtpCipher` are constant after the DTLS handshake, so they appear in a transport's first sample and again only when a value changes — the ufrag changing is exactly an ICE restart, a change worth shipping. Consumers keep the last seen value per transport `id`; **absence means "unchanged", not "unknown"**. `sendIceTransportMetadataOnChangeOnly: false` restores every-sample emission. Dynamic members (`iceState`, `dtlsState`, `selectedCandidatePairId`, `selectedCandidatePairChanges`, byte/packet counters) are unchanged.
+-   **Two new issues: `dtls-handshake-failed` and `dtls-handshake-stalled`** (see the detector below), in the `ClientMonitorIssue`/`ClientMonitorResolvedIssue` unions and the `isClientMonitorIssue` guard.
+-   **`LONG_PC_CONNECTION_ESTABLISHMENT` says where setup is stuck.** The event payload gains `stalledStage` (`'ice-gathering' | 'ice-checking' | 'dtls' | 'unknown'`) plus the most severe transport's `iceState`/`dtlsState` and the pc's `iceGatheringState` — `connectionState: 'connecting'` covers ICE and DTLS alike, and until now the event could not tell a STUN desert from a certificate problem.
+-   **`unstable-ice-path` payload gains `nativePairChanges`** — how many switches the browser's own counter saw inside the window, which can exceed the observed transition count (see below).
+-   **Firefox < 153 reconstructed transport counter is spec-aligned.** `selectedCandidatePairChanges` now counts the first selection as 1, matching the native counter's "going from no selected pair to having one also increments" semantics; it previously landed on 0.
+
+### New: `DtlsHandshakeDetector`
+
+Separates "the network path failed" (the ICE detectors' territory) from "the secure media transport never negotiated", which nothing owned: a certificate fingerprint mismatch, DTLS version intolerance, or a middlebox that passes STUN but eats DTLS all presented as a generically slow `connecting`. `dtlsState: 'failed'` raises `dtls-handshake-failed` immediately; ICE proven healthy while DTLS sits in `new`/`connecting` past `stalledThresholdInMs` (default 6000) raises `dtls-handshake-stalled`. ICE health comes from the transport's `iceState` where the browser reports one, and from the selected pair being `succeeded` where it does not (Safari, and the transport reconstructed for Firefox < 153) — the payload's `iceEvidence` names which proof was used. Never judges a transport on its first observed tick (Firefox 153/154 report pre-negotiation values that only 155 makes trustworthy), never treats `closed` as a failure, and restarts its stall timer when the ufrag changes. Config: `dtlsHandshakeDetector`, `null` to disable.
+
+### One attribution rule for RTP → transport
+
+-   **`attributeRtpToTransport` (utils) / `PeerConnectionMonitor.attributeRtpToTransport()`** is now the single rule mapping RTP streams onto a transport: exact `transportId` match, and streams carrying no `transportId` belong to a transport only when it is the pc's sole transport — exact under BUNDLE, never double-counted without it.
+-   `BlockedTransportDetector` and `MediaPipelineDetector` both use it. They previously disagreed: the pipeline detector's permissive filter counted a `transportId`-less inbound stream against **every** transport of a non-BUNDLE connection, so one quiet stream could raise `media-pipeline-stalled` on two transports at once.
+-   **The traversal graph is complete**: `getIceTransport()` and `getSelectedCandidatePair()` on all four RTP monitors (only the inbound one could traverse before), and `getSelectedIcePath()` on `IceTransportMonitor` — any stream can now answer "is this on TURN?" in two hops.
+
+### Selected-pair churn is counted from the browser
+
+-   **`IceTransportMonitor.deltaSelectedCandidatePairChanges`** differences the native `selectedCandidatePairChanges` counter (Chrome 80+, Firefox 155+; absent on Safari). Counted only once the transport already had a selection, so the first selection is never churn; a backwards counter reads as a reset, not as movement.
+-   **`unstable-ice-path` uses the larger of observed transitions and the native delta.** The path diffing in `SelectedIcePath` remains the classifier and the only portable signal, but it is tick-to-tick and structurally blind to a flap that departs and returns within one collecting period — the native counter sees it. An inferred ICE restart clears the native tally and suppresses the next ticks, so a restart's own reselection never counts.
+
+### Fixed
+
+-   **Peer-connection `iceState` is the most severe state across its transports**, not whatever transport happened to be listed first — a failed transport is no longer masked by a healthy sibling on a non-BUNDLE connection. Severity: `failed > disconnected > checking > new > connected > completed > closed`.
+-   **The `never-established` restart recommendation reports the most severe transport** instead of the first one, for the same reason.
+
 ## 4.7.0
 
 A large release, summarised by what actually changed rather than by the order it was built in. Three themes: **scores now say who is responsible for what**, **detectors were rebuilt around the signal each one can actually see**, and **three new detectors cover failures nothing owned**.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ const monitor = new ClientMonitor({
         maxSendShare: 0.1,            // transport send below this share of produced => not leaving
         stunFreshnessInMs: 10000,     // how recent a STUN response must be to count as verified
     },
+    dtlsHandshakeDetector: {
+        stalledThresholdInMs: 6000,   // ICE healthy but DTLS still `new`/`connecting` for this long
+    },
     noAvailableIceCandidateDetector: {
         thresholdInMs: 6000,          // grace for `new`/`connecting` with zero local candidates
     },
@@ -453,6 +456,7 @@ Configuration follows one convention everywhere: omit a detector's config key to
 | [`LongPcConnectionEstablishmentDetector`](#longpcconnectionestablishmentdetector) | peer connection | event `too-long-pc-connection-establishment` | Connection setup taking suspiciously long |
 | [`IceConnectivityDetector`](#iceconnectivitydetector) | ICE transports | issues `ice-disconnected`, `ice-connection-failed`, `ice-transport-stalled`, `unstable-ice-path`; events `ice-restart`, `ice-restart-recommended` | Runtime ICE health and *when* an ICE restart is warranted |
 | [`BlockedTransportDetector`](#blockedtransportdetector) | ICE transports | issue `blocked-transport` | STUN passes but media does not — the firewall / policy-middlebox signature |
+| [`DtlsHandshakeDetector`](#dtlshandshakedetector) | ICE transports | issues `dtls-handshake-failed`, `dtls-handshake-stalled` | The network path works but the secure media transport never negotiates — certificate mismatch, DTLS intolerance, a middlebox eating DTLS |
 | [`NoAvailableIceCandidateDetector`](#noavailableicecandidatedetector) | peer connection | issue `no-available-ice-candidate` | Zero local ICE candidates while the connection falls over — no usable network at all |
 | [`MediaPipelineDetector`](#mediapipelinedetector) | peer connection | issue `media-pipeline-stalled` | The first broken stage of the media pipeline nothing else covers: encoded frames never leave the sender, or transport traffic never demuxes |
 | [`IceTupleChangeDetector`](#icetuplechangedetector) | ICE transports | event `ice-tuple-changed` | The low-level signal that the selected network tuple changed |
@@ -890,7 +894,7 @@ monitor.on('issue-resolved', (issue) => {
 
 #### LongPcConnectionEstablishmentDetector
 
-Emits `'too-long-pc-connection-establishment'` (and the `LONG_PC_CONNECTION_ESTABLISHMENT` client event) when a peer connection stays in `connecting` past the threshold. Re-arms on any exit from `connecting`, so slow *retries* are reported too.
+Emits `'too-long-pc-connection-establishment'` (and the `LONG_PC_CONNECTION_ESTABLISHMENT` client event) when a peer connection stays in `connecting` past the threshold. Re-arms on any exit from `connecting`, so slow *retries* are reported too. Since 4.8.0 the payload names *where* setup is stuck via `stalledStage` — `'ice-gathering'`, `'ice-checking'`, `'dtls'` or `'unknown'` — because `connecting` covers ICE and the DTLS handshake alike, and the two have different fixes.
 
 **Use the result:** show "connecting is taking longer than usual"; if it repeats, retry with `iceTransportPolicy: 'relay'` to test whether direct connectivity is the blocker. The [`never-established`](#iceconnectivitydetector) restart recommendation is this detector's escalation.
 
@@ -905,7 +909,7 @@ longPcConnectionEstablishmentDetector: {
 
 #### IceConnectivityDetector
 
-Runtime ICE and transport health, per ICE transport (a peer connection without BUNDLE has several, and they fail independently). Raises `ice-disconnected` (only after the threshold — transient blips self-heal), `ice-connection-failed` (immediately — `failed` is terminal for the generation), `ice-transport-stalled` (still sending, receiving nothing, after inbound had been seen) and `unstable-ice-path` (selected path flapping).
+Runtime ICE and transport health, per ICE transport (a peer connection without BUNDLE has several, and they fail independently). Raises `ice-disconnected` (only after the threshold — transient blips self-heal), `ice-connection-failed` (immediately — `failed` is terminal for the generation), `ice-transport-stalled` (still sending, receiving nothing, after inbound had been seen) and `unstable-ice-path` (selected path flapping). Path switches are counted as the larger of the observed path transitions and the browser's own `selectedCandidatePairChanges` counter (Chrome 80+, Firefox 155+), which also sees flaps too fast for tick-to-tick diffing; the issue payload carries the native count as `nativePairChanges`, and an inferred ICE restart never counts as churn.
 
 **Use the result — the restart loop:** the library names *when* an ICE restart is warranted; performing it is the application's job. `'ice-restart-recommended'` carries a `reason` and a `recommendationCount` so you can escalate to a full rejoin when restarts stop helping; `'ice-restart'` then reports whether the restart you performed `recovered` or `failed`.
 
@@ -964,6 +968,24 @@ blockedTransportDetector: {
 **Use the result:** tell the user their network blocks media (a TURN/TLS fallback or a network change is the fix, an ICE restart on the same path is not), and correlate server-side: many `blocked-transport` clients on one corporate network is a firewall policy, not N user problems.
 
 **Sources:** [RFC 7675: STUN consent freshness](https://datatracker.ietf.org/doc/html/rfc7675) · [RTCIceCandidatePairStats (W3C webrtc-stats)](https://www.w3.org/TR/webrtc-stats/#candidatepair-dict*) · [WebRTC and firewalls (BlogGeek.me glossary)](https://bloggeek.me/webrtcglossary/firewall/)
+
+#### DtlsHandshakeDetector
+
+Separates "the network path failed" (the ICE detectors' territory) from "the secure media transport never negotiated", which nothing owned before: a certificate fingerprint mismatch, DTLS version intolerance, or a middlebox that passes STUN but eats DTLS all used to present as a generically slow `connecting`.
+
+Raises two issues, per ICE transport. `dtls-handshake-failed` fires immediately on `dtlsState: 'failed'` — the handshake is terminal for this transport until an ICE restart re-keys it. `dtls-handshake-stalled` fires when the ICE side is proven healthy while `dtlsState` sits in `new`/`connecting` past `stalledThresholdInMs`. ICE health comes from the transport's `iceState` where the browser reports one, and from the selected candidate pair being `succeeded` where it does not (Safari, and the transport reconstructed for Firefox < 153) — the payload's `iceEvidence` names which proof was used.
+
+What it will not judge: a transport on its first observed tick (Firefox 153/154 report pre-negotiation transport values that only 155 makes trustworthy); `dtlsState: 'closed'`, which is a shutdown, not a failure; and a transport whose ICE side is not proven healthy, where the ICE detectors own whatever is wrong. An inferred ICE restart clears the stall timer, since the new generation re-runs the handshake.
+
+```javascript
+dtlsHandshakeDetector: {
+    stalledThresholdInMs: 6000, // ICE healthy, DTLS still `new`/`connecting` for this long
+}
+```
+
+**Use the result:** `dtls-handshake-failed` is a configuration or interop problem, not a network problem — check certificate fingerprints in signaling and TLS interception on the client's network; an ICE restart on the same path *can* help because it re-keys DTLS. Server-side, a failure rate concentrated on one browser version is a browser regression; concentrated on one customer network, a middleware/DPI policy.
+
+**Sources:** [RTCDtlsTransport.state (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/state) · [RTCTransportStats (W3C webrtc-stats)](https://www.w3.org/TR/webrtc-stats/#transportstats-dict*) · [RFC 8827: WebRTC Security Architecture](https://datatracker.ietf.org/doc/html/rfc8827)
 
 #### NoAvailableIceCandidateDetector
 
@@ -1598,6 +1620,11 @@ Sampling creates periodic snapshots (`ClientSample`) containing the complete sta
 
 ### Sample Structure
 
+The sample schema version is **3.7.0** (`ClientMonitor.samplingSchemaVersion`). Two things to know on the consuming side:
+
+-   **Payloads may nest.** Client event, issue, meta and extension-stat payloads are records that may carry nested structures — records on the wire, never pre-serialised JSON strings. (`PEER_CONNECTION_ICE_PATH_CHANGED` ships its `from`/`to` path evidence as structured records since 3.7.0.)
+-   **Static ICE transport metadata ships on change only.** `iceRole`, `dtlsRole`, `iceLocalUsernameFragment`, `tlsVersion`, `dtlsCipher`, `srtpCipher` and the certificate references appear in a transport's first sample and again only when a value changes — absence means *unchanged*, not unknown; keep the last seen value per transport `id`. Set `sendIceTransportMetadataOnChangeOnly: false` to restore every-sample emission.
+
 A `ClientSample` includes:
 
 -   **Client metadata**: clientId, callId, timestamp, score
@@ -1840,6 +1867,8 @@ Most built-in detectors raise their own stateful issue with a typed payload, emi
 | `ice-connection-failed` | An ICE transport reached `failed` | ICE reconnects (typically after a restart) | — | `IceConnectionFailedIssuePayload` |
 | `ice-transport-stalled` | Still sending on a succeeded pair of a connected transport, but receiving nothing for `transportStallThresholdInMs` | Inbound traffic resumes | — | `IceTransportStalledIssuePayload` |
 | `unstable-ice-path` | `pathSwitchThreshold` selected-path switches within `pathSwitchWindowInMs` | The window drains | — | `UnstableIcePathIssuePayload` |
+| `dtls-handshake-failed` | An ICE transport reached `dtlsState: 'failed'` | A later handshake connects (after an ICE restart re-keys it) | `'dtls-handshake-failed'` | `DtlsHandshakeFailedIssuePayload` |
+| `dtls-handshake-stalled` | ICE proven healthy while DTLS sat in `new`/`connecting` past `stalledThresholdInMs` | The handshake completes | `'dtls-handshake-stalled'` | `DtlsHandshakeStalledIssuePayload` |
 | `audio-concealment` | Audible concealment share (silence excluded) crosses `onThreshold` over the window | Share falls below `offThreshold` | `'audio-concealment'` | `AudioConcealmentIssuePayload` |
 | `audio-jitter-buffer-stress` | Target delay grown **and** NetEQ time-stretching, for `minConsecutiveTicks` | Either condition clears | `'audio-jitter-buffer-stress'` | `JitterBufferStressIssuePayload` |
 | `video-decoder-overloaded` | Frames arrived and loss was quiet, but decode time overran the frame budget or frames were dropped after arrival | The decoder keeps up again | `'video-decoder-overloaded'` | `DecoderPerformanceIssuePayload` |
@@ -2194,6 +2223,8 @@ monitor.on('ice-path-changed',      (e) => { /* selected path changed: direct <-
 monitor.on('ice-restart',           (e) => { /* a new ICE generation was inferred */ });
 monitor.on('ice-restart-recommended', (e) => { /* YOUR app decides whether to restartIce() */ });
 monitor.on('ice-tuple-changed',     (e) => { /* low-level: the selected tuple set changed */ });
+monitor.on('dtls-handshake-failed',  (e) => { /* DTLS is terminal for this transport — config/interop, not network */ });
+monitor.on('dtls-handshake-stalled', (e) => { /* ICE fine, DTLS not completing — something eats DTLS */ });
 monitor.on('new-selected-ice-path', (e) => { /* an ICE transport selected its first path */ });
 
 // Score & stats lifecycle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observertc/client-monitor-js",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "ObserveRTC Client Integration Javascript Library",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/ClientMonitor.ts
+++ b/src/ClientMonitor.ts
@@ -283,6 +283,13 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
             bufferingEventsForSamples: monitorConfig.bufferingEventsForSamples ?? false,
             sendResolvedIssuesToServer: monitorConfig.sendResolvedIssuesToServer ?? true,
             sendScoreReasonsToServer: monitorConfig.sendScoreReasonsToServer ?? true,
+            sendIceTransportMetadataOnChangeOnly: monitorConfig.sendIceTransportMetadataOnChangeOnly ?? true,
+            dtlsHandshakeDetector: detectorDefault(monitorConfig.dtlsHandshakeDetector, {
+                // sits between the ICE detectors' 5000ms thresholds and
+                // noAvailableIceCandidateDetector's 6000ms, so ICE-level causes
+                // are reported by their own detectors first
+                stalledThresholdInMs: 6000,
+            }),
             appData: monitorConfig.appData ?? {} as AppData,
         }
 

--- a/src/ClientMonitorConfig.ts
+++ b/src/ClientMonitorConfig.ts
@@ -671,6 +671,30 @@ export type AppliedClientMonitorConfig<AppData extends Record<string, unknown> =
     } | null;
 
     /**
+     * Configuration for detecting DTLS handshake trouble on an ICE transport:
+     * a `dtlsState` of `failed` (terminal for the handshake), or a transport
+     * whose ICE side is proven healthy while DTLS sits in `new`/`connecting`
+     * past `stalledThresholdInMs` — the signature that separates a network
+     * connectivity failure (owned by the ICE detectors) from a secure media
+     * transport negotiation failure: certificate fingerprint mismatch, DTLS
+     * version intolerance, or a middlebox that passes STUN but eats DTLS.
+     *
+     * Where the browser reports no transport `iceState` (Safari, and the
+     * transport reconstructed for Firefox < 153), ICE health is proven by the
+     * selected candidate pair being `succeeded` instead.
+     *
+     * Pass `null` to disable the detector entirely.
+     */
+    dtlsHandshakeDetector: {
+        /**
+         * How long (in milliseconds) DTLS may stay in `new`/`connecting` on a
+         * transport whose ICE side is already healthy before the stall issue
+         * is raised. `dtlsState: 'failed'` raises immediately regardless.
+         */
+        stalledThresholdInMs: number;
+    } | null;
+
+    /**
      * Configuration for detecting that the client has no usable network at
      * all: ICE gathering produced zero local candidates while the peer
      * connection falls to `disconnected`/`failed` (or never leaves
@@ -762,6 +786,20 @@ export type AppliedClientMonitorConfig<AppData extends Record<string, unknown> =
      * DEFAULT: true (only an explicit `false` disables shipping)
      */
     sendScoreReasonsToServer?: boolean;
+
+    /**
+     * Whether the mostly-static ICE transport metadata (`iceRole`, `dtlsRole`,
+     * `iceLocalUsernameFragment`, `tlsVersion`, `dtlsCipher`, `srtpCipher` and
+     * the certificate references) is shipped only in the first sample of a
+     * transport and again when one of the values changes, instead of being
+     * repeated in every sample. The values are constant after the DTLS
+     * handshake, so on-change emission removes pure redundancy from the wire;
+     * the ufrag changing is exactly an ICE restart, which is a change worth
+     * shipping. Set to `false` to restore the legacy every-sample emission.
+     *
+     * DEFAULT: true (only an explicit `false` disables on-change emission)
+     */
+    sendIceTransportMetadataOnChangeOnly?: boolean;
 
     /**
      * Additional metadata to be included in the client monitor.

--- a/src/ClientMonitorEvents.ts
+++ b/src/ClientMonitorEvents.ts
@@ -23,23 +23,20 @@ import { SimulcastLayerState } from "./detectors/SimulcastLayerDetector";
 import { VideoResolutionChangeDirection } from "./detectors/VideoResolutionChangeDetector";
 import { StuckDecoderVariant } from "./detectors/StuckDecoderDetector";
 import { BlockedTransportIssuePayload } from "./detectors/BlockedTransportDetector";
+import { DtlsHandshakeFailedIssuePayload, DtlsHandshakeStalledIssuePayload } from "./detectors/DtlsHandshakeDetector";
+import { LongPcConnectionEstablishmentStage } from "./detectors/LongPcConnectionEstablishment";
 import { NoAvailableIceCandidateIssuePayload } from "./detectors/NoAvailableIceCandidateDetector";
 import { MediaPipelineStalledIssuePayload } from "./detectors/MediaPipelineDetector";
 
 /**
- * A value the ClientSample schema (3.5.0) can carry inside a payload:
- * payloads are flat records of primitives on the wire, never nested
- * structures and never pre-serialised JSON strings.
- */
-export type ClientPayloadValue = boolean | string | number;
-
-/**
  * The shape every sampled payload must have — client events, client issues,
- * meta items and extension stats all carry this. `undefined` and `null`
- * entries are legal on the API (DOM types produce them); `undefined` keys
- * disappear when the sample serialises.
+ * meta items and extension stats all carry this. Since schema 3.7.0 payloads
+ * may carry nested structures, not only flat records of primitives; they are
+ * records on the wire, never pre-serialised JSON strings. `undefined` and
+ * `null` entries are legal on the API (DOM types produce them); `undefined`
+ * keys disappear when the sample serialises.
  */
-export type ClientPayload = Record<string, ClientPayloadValue | null | undefined>;
+export type ClientPayload = Record<string, unknown>;
 
 export type ClientIssuePayload = ClientPayload;
 
@@ -162,6 +159,8 @@ export type DryOutboundTrackEventPayload = ClientMonitorBaseEvent & {
 
 export type TooLongPcConnectionEstablishmentEventPayload = ClientMonitorBaseEvent & {
 	peerConnectionMonitor: PeerConnectionMonitor,
+	/** Which stage of establishment the connection is actually stuck in. */
+	stalledStage: LongPcConnectionEstablishmentStage,
 }
 
 export type IceTupleChangedEventPayload = ClientMonitorBaseEvent & {
@@ -193,6 +192,14 @@ export type BlockedTransportEventPayload = ClientMonitorBaseEvent
 export type NoAvailableIceCandidateEventPayload = ClientMonitorBaseEvent
 	& { peerConnectionMonitor: PeerConnectionMonitor }
 	& NoAvailableIceCandidateIssuePayload;
+
+export type DtlsHandshakeFailedEventPayload = ClientMonitorBaseEvent
+	& { peerConnectionMonitor: PeerConnectionMonitor }
+	& DtlsHandshakeFailedIssuePayload;
+
+export type DtlsHandshakeStalledEventPayload = ClientMonitorBaseEvent
+	& { peerConnectionMonitor: PeerConnectionMonitor }
+	& DtlsHandshakeStalledIssuePayload;
 
 export type MediaPipelineStalledEventPayload = ClientMonitorBaseEvent
 	& { peerConnectionMonitor: PeerConnectionMonitor }
@@ -417,6 +424,8 @@ export type ClientMonitorEvents = {
 	'ice-restart': [IceRestartEventPayload],
 	'ice-restart-recommended': [IceRestartRecommendedEventPayload],
 	'blocked-transport': [BlockedTransportEventPayload],
+	'dtls-handshake-failed': [DtlsHandshakeFailedEventPayload],
+	'dtls-handshake-stalled': [DtlsHandshakeStalledEventPayload],
 	'no-available-ice-candidate': [NoAvailableIceCandidateEventPayload],
 	'media-pipeline-stalled': [MediaPipelineStalledEventPayload],
 	'audio-concealment': [AudioConcealmentEventPayload],

--- a/src/ClientMonitorIssues.ts
+++ b/src/ClientMonitorIssues.ts
@@ -28,6 +28,10 @@ import {
 } from "./detectors/CaptureFailureDetector";
 import { StuckDecoderIssuePayload } from "./detectors/StuckDecoderDetector";
 import { BlockedTransportIssuePayload } from "./detectors/BlockedTransportDetector";
+import {
+    DtlsHandshakeFailedIssuePayload,
+    DtlsHandshakeStalledIssuePayload,
+} from "./detectors/DtlsHandshakeDetector";
 import { NoAvailableIceCandidateIssuePayload } from "./detectors/NoAvailableIceCandidateDetector";
 import { MediaPipelineStalledIssuePayload } from "./detectors/MediaPipelineDetector";
 
@@ -117,6 +121,8 @@ export type ClientMonitorIssue =
     | RaisedClientIssue<SilentAudioSourceIssuePayload>     & { type: 'silent-audio-source' }
     | RaisedClientIssue<StuckDecoderIssuePayload>          & { type: 'stuck-decoder' }
     | RaisedClientIssue<BlockedTransportIssuePayload>         & { type: 'blocked-transport' }
+    | RaisedClientIssue<DtlsHandshakeFailedIssuePayload>      & { type: 'dtls-handshake-failed' }
+    | RaisedClientIssue<DtlsHandshakeStalledIssuePayload>     & { type: 'dtls-handshake-stalled' }
     | RaisedClientIssue<NoAvailableIceCandidateIssuePayload>    & { type: 'no-available-ice-candidate' }
     | RaisedClientIssue<MediaPipelineStalledIssuePayload>       & { type: 'media-pipeline-stalled' };
 
@@ -151,6 +157,8 @@ export type ClientMonitorResolvedIssue =
     | ResolvedClientIssue<SilentAudioSourceIssuePayload>     & { type: 'silent-audio-source' }
     | ResolvedClientIssue<StuckDecoderIssuePayload>          & { type: 'stuck-decoder' }
     | ResolvedClientIssue<BlockedTransportIssuePayload>         & { type: 'blocked-transport' }
+    | ResolvedClientIssue<DtlsHandshakeFailedIssuePayload>      & { type: 'dtls-handshake-failed' }
+    | ResolvedClientIssue<DtlsHandshakeStalledIssuePayload>     & { type: 'dtls-handshake-stalled' }
     | ResolvedClientIssue<NoAvailableIceCandidateIssuePayload>    & { type: 'no-available-ice-candidate' }
     | ResolvedClientIssue<MediaPipelineStalledIssuePayload>       & { type: 'media-pipeline-stalled' };
 
@@ -189,6 +197,8 @@ export function isClientMonitorIssue(
         case 'silent-audio-source':
         case 'stuck-decoder':
         case 'blocked-transport':
+        case 'dtls-handshake-failed':
+        case 'dtls-handshake-stalled':
         case 'no-available-ice-candidate':
         case 'media-pipeline-stalled':
             return true;

--- a/src/adapters/FirefoxStatsAdapter.ts
+++ b/src/adapters/FirefoxStatsAdapter.ts
@@ -80,7 +80,10 @@ export class FirefoxStatsAdapter implements StatsAdapter {
 		bytesSent: 0,
 		bytesReceived: 0,
 		selectedCandidatePairId: undefined,
-		selectedCandidatePairChanges: -1,
+		// Spec semantics: "initially zero", and going from no selected pair to
+		// having one also increments — so the first selection lands on 1, the
+		// same as a native counter.
+		selectedCandidatePairChanges: 0,
 	};
 
 	private _selectedCandidatePair?: SelectedIceCandidatePairStats;

--- a/src/detectors/BlockedTransportDetector.ts
+++ b/src/detectors/BlockedTransportDetector.ts
@@ -1,6 +1,7 @@
 import { IceTransportMonitor } from "../monitors/IceTransportMonitor";
 import { IcePathKind } from "../monitors/IceCandidatePairMonitor";
 import { PeerConnectionMonitor } from "../monitors/PeerConnectionMonitor";
+import { attributeRtpToTransport } from "../utils/common";
 import { Detector } from "./Detector";
 
 /**
@@ -201,13 +202,10 @@ export class BlockedTransportDetector implements Detector {
 		);
 	}
 
-	/** When no outbound RTP carries a `transportId` (some browsers omit it), every stream is attributed to the transport — exact under BUNDLE. */
 	private _outboundMediaBitrateOf(transport: IceTransportMonitor): number {
-		const outboundRtps = this.peerConnection.outboundRtps;
-		const attributed = outboundRtps.filter((outboundRtp) => outboundRtp.transportId === transport.id);
-		const relevant = 0 < attributed.length
-			? attributed
-			: outboundRtps.filter((outboundRtp) => outboundRtp.transportId === undefined);
+		const relevant = attributeRtpToTransport(
+			this.peerConnection.outboundRtps, transport.id, this.peerConnection.iceTransports.length,
+		);
 
 		return relevant.reduce((acc, outboundRtp) => acc + (outboundRtp.bitrate ?? 0), 0);
 	}

--- a/src/detectors/DtlsHandshakeDetector.ts
+++ b/src/detectors/DtlsHandshakeDetector.ts
@@ -1,0 +1,316 @@
+import { IceTransportMonitor } from "../monitors/IceTransportMonitor";
+import { PeerConnectionMonitor } from "../monitors/PeerConnectionMonitor";
+import { Detector } from "./Detector";
+
+/** How the detector proved the ICE side healthy before judging DTLS. */
+export type DtlsIceEvidence =
+	/** The transport reported `iceState` `connected`/`completed`. */
+	| 'transport-ice-state'
+	/**
+	 * The transport carries no `iceState` (Safari, and the transport
+	 * reconstructed for Firefox < 153): the selected candidate pair being
+	 * `succeeded` stood in for it.
+	 */
+	| 'selected-pair-succeeded';
+
+export type DtlsHandshakeFailedIssuePayload = {
+	peerConnectionId: string;
+	transportId: string;
+	dtlsState?: string;
+	iceState?: string;
+	selectedCandidatePairId?: string;
+	/** Filled in when the issue is resolved. */
+	durationInMs?: number;
+};
+
+export type DtlsHandshakeStalledIssuePayload = {
+	peerConnectionId: string;
+	transportId: string;
+	dtlsState?: string;
+	iceState?: string;
+	iceEvidence: DtlsIceEvidence;
+	selectedCandidatePairId?: string;
+	/** How long DTLS had already sat in `new`/`connecting` when the issue was raised. */
+	stalledForMs: number;
+	/** Filled in when the issue is resolved. */
+	durationInMs?: number;
+};
+
+type TransportState = {
+	/** Update ticks this transport has been observed for — the first tick is never judged. */
+	ticks: number;
+	usernameFragment?: string;
+	stalledSince?: number;
+	stalledRaisedAt?: number;
+	failedRaisedAt?: number;
+};
+
+const FAILED_ISSUE_TYPE = 'dtls-handshake-failed';
+const STALLED_ISSUE_TYPE = 'dtls-handshake-stalled';
+
+/**
+ * Separates "the network path failed" from "the secure media transport never
+ * negotiated". The ICE detectors own the first; until now nothing owned the
+ * second: a certificate fingerprint mismatch, DTLS version intolerance, or a
+ * middlebox that passes STUN but eats DTLS all presented as a generically slow
+ * `connecting` peer connection.
+ *
+ * Two findings share the per-transport state. *Failure*: `dtlsState: 'failed'`
+ * raises `dtls-handshake-failed` immediately — the handshake is terminal for
+ * this transport until an ICE restart re-keys it. *Stall*: ICE proven healthy
+ * while `dtlsState` sits in `new`/`connecting` past `stalledThresholdInMs`
+ * raises `dtls-handshake-stalled`. ICE health comes from the transport's
+ * `iceState` where the browser reports one, and from the selected candidate
+ * pair being `succeeded` where it does not (Safari, Firefox < 153) — the same
+ * proxy `BlockedTransportDetector` uses.
+ *
+ * What it will not judge: a transport on its first observed tick (Firefox
+ * 153/154 report pre-negotiation transport values that only 155 makes
+ * trustworthy); `dtlsState: 'closed'`, which is a shutdown, not a failure; and
+ * a transport whose ICE side is not proven healthy, where a DTLS stall cannot
+ * be told from ICE still working. A changed ICE local username fragment (an
+ * ICE restart) clears the stall timer, since the new generation re-runs the
+ * handshake.
+ *
+ * Issues raised: `dtls-handshake-failed`, `dtls-handshake-stalled`. Monitor
+ * events of the same names. Config: `dtlsHandshakeDetector`.
+ */
+export class DtlsHandshakeDetector implements Detector {
+	public static readonly FAILED_ISSUE_TYPE = FAILED_ISSUE_TYPE;
+	public static readonly STALLED_ISSUE_TYPE = STALLED_ISSUE_TYPE;
+
+	public readonly name = 'dtls-handshake-detector';
+	public disabled = false;
+	public includeIssueInSample = true;
+
+	private readonly _states = new Map<string, TransportState>();
+
+	public constructor(
+		public readonly peerConnection: PeerConnectionMonitor,
+	) {
+	}
+
+	private get config() {
+		return this.peerConnection.parent.config.dtlsHandshakeDetector!;
+	}
+
+	public update(): void {
+		if (this.disabled) return;
+		if (this.peerConnection.closed) return;
+
+		const seenIds = new Set<string>();
+
+		for (const transport of this.peerConnection.iceTransports) {
+			seenIds.add(transport.id);
+			this._checkTransport(transport);
+		}
+
+		for (const id of [ ...this._states.keys() ]) {
+			if (seenIds.has(id)) continue;
+
+			this._resolveAll(id, 'ice transport is gone');
+			this._states.delete(id);
+		}
+	}
+
+	private _checkTransport(transport: IceTransportMonitor) {
+		const state = this._getState(transport);
+		const ticks = state.ticks;
+
+		state.ticks += 1;
+
+		// An ICE restart re-keys DTLS: the stall timer must restart with the new generation.
+		const usernameFragment = this._usernameFragmentOf(transport);
+
+		if (usernameFragment !== undefined && state.usernameFragment !== undefined
+			&& usernameFragment !== state.usernameFragment) {
+			state.stalledSince = undefined;
+		}
+		if (usernameFragment !== undefined) state.usernameFragment = usernameFragment;
+
+		const dtlsState = transport.dtlsState;
+
+		if (dtlsState === 'failed') {
+			state.stalledSince = undefined;
+
+			this._resolveStalled(transport.id, state, 'dtls handshake failed');
+
+			if (state.failedRaisedAt !== undefined) return;
+
+			state.failedRaisedAt = Date.now();
+
+			const payload: DtlsHandshakeFailedIssuePayload = {
+				peerConnectionId: this.peerConnection.peerConnectionId,
+				transportId: transport.id,
+				dtlsState,
+				iceState: transport.iceState,
+				selectedCandidatePairId: transport.selectedCandidatePairId,
+			};
+
+			const clientMonitor = this.peerConnection.parent;
+
+			clientMonitor.emit('dtls-handshake-failed', {
+				clientMonitor,
+				peerConnectionMonitor: this.peerConnection,
+				...payload,
+			});
+
+			clientMonitor.raiseIssue<DtlsHandshakeFailedIssuePayload>(
+				this._issueKey(FAILED_ISSUE_TYPE, transport.id),
+				{
+					includeInSample: this.includeIssueInSample,
+					type: FAILED_ISSUE_TYPE,
+					payload,
+				}
+			);
+
+			return;
+		}
+
+		if (dtlsState === 'connected') {
+			state.stalledSince = undefined;
+
+			this._resolveStalled(transport.id, state, 'dtls handshake completed');
+			this._resolveFailed(transport.id, state, 'dtls handshake completed');
+
+			return;
+		}
+
+		// 'closed' is a shutdown, not a failure; and without a dtlsState there is nothing to judge.
+		if (dtlsState !== 'new' && dtlsState !== 'connecting') {
+			state.stalledSince = undefined;
+
+			return;
+		}
+
+		// Firefox 153/154 report pre-negotiation transport values that only 155
+		// makes trustworthy — a transport is never judged on its first tick.
+		if (ticks < 1) return;
+
+		const iceEvidence = this._iceHealthEvidence(transport);
+
+		if (iceEvidence === undefined) {
+			// ICE itself is not proven healthy: the ICE detectors own whatever is wrong.
+			state.stalledSince = undefined;
+
+			return;
+		}
+
+		if (state.stalledSince === undefined) {
+			state.stalledSince = Date.now();
+		}
+
+		const stalledForMs = Date.now() - state.stalledSince;
+
+		if (stalledForMs < this.config.stalledThresholdInMs) return;
+		if (state.stalledRaisedAt !== undefined) return;
+
+		state.stalledRaisedAt = Date.now();
+
+		const payload: DtlsHandshakeStalledIssuePayload = {
+			peerConnectionId: this.peerConnection.peerConnectionId,
+			transportId: transport.id,
+			dtlsState,
+			iceState: transport.iceState,
+			iceEvidence,
+			selectedCandidatePairId: transport.selectedCandidatePairId,
+			stalledForMs,
+		};
+
+		const clientMonitor = this.peerConnection.parent;
+
+		clientMonitor.emit('dtls-handshake-stalled', {
+			clientMonitor,
+			peerConnectionMonitor: this.peerConnection,
+			...payload,
+		});
+
+		clientMonitor.raiseIssue<DtlsHandshakeStalledIssuePayload>(
+			this._issueKey(STALLED_ISSUE_TYPE, transport.id),
+			{
+				includeInSample: this.includeIssueInSample,
+				type: STALLED_ISSUE_TYPE,
+				payload,
+			}
+		);
+	}
+
+	/**
+	 * Proof that the ICE side of the transport is healthy, so a quiet DTLS
+	 * handshake is DTLS's own fault. `undefined` means no proof — not proof of
+	 * the opposite.
+	 */
+	private _iceHealthEvidence(transport: IceTransportMonitor): DtlsIceEvidence | undefined {
+		const iceState = transport.iceState;
+
+		if (iceState === 'connected' || iceState === 'completed') return 'transport-ice-state';
+		if (iceState !== undefined) return undefined;
+
+		return transport.getSelectedCandidatePair()?.state === 'succeeded'
+			? 'selected-pair-succeeded'
+			: undefined;
+	}
+
+	private _usernameFragmentOf(transport: IceTransportMonitor): string | undefined {
+		return transport.iceLocalUsernameFragment
+			?? transport.getSelectedCandidatePair()?.getLocalCandidate()?.usernameFragment;
+	}
+
+	private _resolveStalled(transportId: string, state: TransportState, comment: string) {
+		if (state.stalledRaisedAt === undefined) return;
+
+		this._resolveIssue(STALLED_ISSUE_TYPE, transportId, state.stalledRaisedAt, comment);
+		state.stalledRaisedAt = undefined;
+	}
+
+	private _resolveFailed(transportId: string, state: TransportState, comment: string) {
+		if (state.failedRaisedAt === undefined) return;
+
+		this._resolveIssue(FAILED_ISSUE_TYPE, transportId, state.failedRaisedAt, comment);
+		state.failedRaisedAt = undefined;
+	}
+
+	private _resolveAll(transportId: string, comment: string) {
+		const state = this._states.get(transportId);
+
+		if (!state) return;
+
+		this._resolveStalled(transportId, state, comment);
+		this._resolveFailed(transportId, state, comment);
+	}
+
+	private _resolveIssue(type: string, transportId: string, raisedAt: number | undefined, comment: string) {
+		const clientMonitor = this.peerConnection.parent;
+		const key = this._issueKey(type, transportId);
+		const issue = clientMonitor.activeIssues.get(key);
+
+		if (!issue) return;
+
+		clientMonitor.resolveIssue(key, {
+			comment,
+			payload: {
+				...issue.payload,
+				durationInMs: raisedAt !== undefined ? Date.now() - raisedAt : undefined,
+			},
+			resolvedAt: Date.now(),
+		});
+	}
+
+	private _getState(transport: IceTransportMonitor): TransportState {
+		let state = this._states.get(transport.id);
+
+		if (!state) {
+			state = {
+				ticks: 0,
+				usernameFragment: this._usernameFragmentOf(transport),
+			};
+			this._states.set(transport.id, state);
+		}
+
+		return state;
+	}
+
+	private _issueKey(type: string, transportId: string) {
+		return `${type}-pc-${this.peerConnection.peerConnectionId}-transport-${transportId}`;
+	}
+}

--- a/src/detectors/IceConnectivityDetector.ts
+++ b/src/detectors/IceConnectivityDetector.ts
@@ -64,6 +64,14 @@ export type UnstableIcePathIssuePayload = {
 	switches: number;
 	windowInMs: number;
 	kind: IcePathKind;
+	/**
+	 * Switches inside the window according to the browser's own
+	 * `selectedCandidatePairChanges` counter, when the browser reports one
+	 * (Chrome 80+, Firefox 155+). It also counts flaps too fast for the
+	 * tick-to-tick path diffing to observe, which is why `switches` can
+	 * exceed the observed transition count.
+	 */
+	nativePairChanges?: number;
 	durationInMs?: number;
 };
 
@@ -138,6 +146,19 @@ type TransportState = {
 	restartRecommendations: number;
 	inboundStalledSince?: number;
 	stallRaisedAt?: number;
+
+	/**
+	 * When the browser reported a selected-pair change through the native
+	 * `selectedCandidatePairChanges` counter: one entry per change, timestamped
+	 * at the tick that observed it. Complements the path diffing, which cannot
+	 * see a flap that departs and returns within one collecting period.
+	 */
+	nativeSwitchTimestamps: number[];
+	/**
+	 * Ticks left during which native pair changes are not recorded — set on an
+	 * inferred ICE restart, whose own reselection is not churn.
+	 */
+	suppressNativeChurnTicks: number;
 };
 
 const DISCONNECTED_ISSUE_TYPE = 'ice-disconnected';
@@ -226,6 +247,8 @@ export class IceConnectivityDetector implements Detector {
 			this._checkIceState(transport, state);
 			this._checkInboundStall(transport, state);
 			this._checkIceRestart(transport, state);
+			// after restart detection, which suppresses the restart's own reselection
+			this._recordNativePairChanges(transport, state);
 			recommendedThisTick = this._checkRestartRecommendation(transport, state) || recommendedThisTick;
 		}
 
@@ -241,10 +264,45 @@ export class IceConnectivityDetector implements Detector {
 	}
 
 	/**
+	 * Records this tick's native selected-pair changes, when the browser reports
+	 * the `selectedCandidatePairChanges` counter (Chrome 80+, Firefox 155+). The
+	 * path diffing in `SelectedIcePath` is the classifier and the portable
+	 * fallback, but it is tick-to-tick and structurally blind to a flap that
+	 * departs and returns within one collecting period — the native counter is
+	 * the browser's own ground truth for *how many* switches happened.
+	 */
+	private _recordNativePairChanges(transport: IceTransportMonitor, state: TransportState) {
+		if (0 < state.suppressNativeChurnTicks) {
+			state.suppressNativeChurnTicks -= 1;
+
+			return;
+		}
+
+		const delta = transport.deltaSelectedCandidatePairChanges;
+
+		if (delta === undefined || delta <= 0) return;
+
+		const now = Date.now();
+		const since = now - this.config.pathSwitchWindowInMs;
+
+		for (let i = 0; i < Math.min(delta, 16); ++i) {
+			state.nativeSwitchTimestamps.push(now);
+		}
+
+		state.nativeSwitchTimestamps = state.nativeSwitchTimestamps.filter((timestamp) => since <= timestamp);
+
+		if (64 < state.nativeSwitchTimestamps.length) {
+			state.nativeSwitchTimestamps.splice(0, state.nativeSwitchTimestamps.length - 64);
+		}
+	}
+
+	/**
 	 * Raises `unstable-ice-path` when a selected path switched at least `pathSwitchThreshold` times
 	 * inside `pathSwitchWindowInMs` — a path that keeps moving is a different failure from one that is
-	 * down, and the switching itself is what the user hears. Resolved when the rate falls back below
-	 * the threshold, or when the path disappears.
+	 * down, and the switching itself is what the user hears. Counted as the larger of the observed
+	 * path transitions and the browser's own `selectedCandidatePairChanges` deltas, which also see
+	 * flaps too fast for tick-to-tick diffing. Resolved when the rate falls back below the threshold,
+	 * or when the path disappears.
 	 */
 	private _checkPathStability() {
 		const { pathSwitchWindowInMs, pathSwitchThreshold } = this.config;
@@ -254,7 +312,10 @@ export class IceConnectivityDetector implements Detector {
 		for (const path of this.peerConnection.selectedIcePaths) {
 			seenKeys.add(path.key);
 
-			const switches = path.getSwitchCountSince(now - pathSwitchWindowInMs);
+			const since = now - pathSwitchWindowInMs;
+			const nativePairChanges = this._states.get(path.transportId ?? '')
+				?.nativeSwitchTimestamps.filter((timestamp) => since <= timestamp).length ?? 0;
+			const switches = Math.max(path.getSwitchCountSince(since), nativePairChanges);
 			const raisedAt = this._unstablePaths.get(path.key);
 
 			if (switches < pathSwitchThreshold) {
@@ -281,6 +342,7 @@ export class IceConnectivityDetector implements Detector {
 						switches,
 						windowInMs: pathSwitchWindowInMs,
 						kind: path.kind,
+						nativePairChanges: 0 < nativePairChanges ? nativePairChanges : undefined,
 					},
 				}
 			);
@@ -304,6 +366,8 @@ export class IceConnectivityDetector implements Detector {
 				restartPending: false,
 				sawInboundTraffic: false,
 				restartRecommendations: 0,
+				nativeSwitchTimestamps: [],
+				suppressNativeChurnTicks: 0,
 			};
 			this._states.set(transport.id, state);
 		}
@@ -347,6 +411,9 @@ export class IceConnectivityDetector implements Detector {
 		state.stallRaisedAt = undefined;
 		state.inboundStalledSince = undefined;
 		state.sawInboundTraffic = false;
+		// the restart's own reselection increments the native counter, and is not churn
+		state.nativeSwitchTimestamps = [];
+		state.suppressNativeChurnTicks = 2;
 
 		this._notifyRestart(transport, state, 'detected');
 	}
@@ -614,16 +681,29 @@ export class IceConnectivityDetector implements Detector {
 		this._establishmentRecommendedAt = now;
 		this._establishmentRecommendations += 1;
 
-		const [ firstTransport ] = this.peerConnection.iceTransports;
+		// The transport whose state best explains the stall — the most severe one.
+		// A connection without BUNDLE has several transports, and the failing one
+		// is the story, not whichever healthy sibling happened to be listed first.
+		const severity: Record<string, number> = {
+			failed: 6, disconnected: 5, checking: 4, new: 3, connected: 2, completed: 1, closed: 0,
+		};
+		let subject: IceTransportMonitor | undefined;
+
+		for (const transport of this.peerConnection.iceTransports) {
+			if (subject === undefined
+				|| (severity[subject.iceState ?? ''] ?? -1) < (severity[transport.iceState ?? ''] ?? -1)) {
+				subject = transport;
+			}
+		}
 
 		this._recommendRestart({
 			peerConnectionId: this.peerConnection.peerConnectionId,
 			reason: 'never-established',
 			conditionDurationInMs,
-			iceGeneration: this._states.get(firstTransport?.id ?? '')?.iceGeneration ?? 0,
+			iceGeneration: this._states.get(subject?.id ?? '')?.iceGeneration ?? 0,
 			recommendationCount: this._establishmentRecommendations,
-			iceState: firstTransport?.iceState,
-			dtlsState: firstTransport?.dtlsState,
+			iceState: subject?.iceState,
+			dtlsState: subject?.dtlsState,
 		});
 	}
 

--- a/src/detectors/LongPcConnectionEstablishment.ts
+++ b/src/detectors/LongPcConnectionEstablishment.ts
@@ -52,20 +52,81 @@ export class LongPcConnectionEstablishmentDetector implements Detector{
 		}
 		this._evented = true;
 		const clientMonitor = this.peerConnection.parent;
+		const stalledStage = this._stalledStage();
 
 		clientMonitor.emit('too-long-pc-connection-establishment', {
 			peerConnectionMonitor: this.peerConnection,
 			clientMonitor,
+			stalledStage,
 		});
 
 		if (this.config.createEvent) {
+			const [ transport ] = this._sortedBySeverity();
+
 			clientMonitor.addEvent({
 				type: ClientEventTypes.LONG_PC_CONNECTION_ESTABLISHMENT,
 				payload: {
 					peerConnectionId: this.peerConnection.peerConnectionId,
 					duration,
+					// `connecting` covers both ICE and DTLS — this names which of them
+					// the connection is actually stuck in.
+					stalledStage,
+					iceState: transport?.iceState,
+					dtlsState: transport?.dtlsState,
+					iceGatheringState: this.peerConnection.iceGatheringState,
 				}
 			})
 		}
 	}
+
+	/**
+	 * Where establishment is actually stuck. `connectionState: 'connecting'`
+	 * covers ICE and the DTLS handshake alike; the per-transport states can name
+	 * the stage — `ice-gathering` before any transport exists, `ice-checking`
+	 * while a transport is still negotiating connectivity, `dtls` once every
+	 * transport's ICE side is done (proven by `iceState` where the browser
+	 * reports one, by the selected pair being `succeeded` where it does not) yet
+	 * the connection still is not `connected`, and `unknown` when the stats give
+	 * no verdict.
+	 */
+	private _stalledStage(): LongPcConnectionEstablishmentStage {
+		// nullish-guarded so a partially mocked monitor (tests, custom sources) stays judgeable
+		const transports = this.peerConnection.iceTransports ?? [];
+
+		if (transports.length === 0) {
+			return this.peerConnection.iceGatheringState === 'gathering' ? 'ice-gathering' : 'unknown';
+		}
+
+		let anyIceDone = false;
+
+		for (const transport of transports) {
+			const iceState = transport.iceState;
+
+			if (iceState === 'checking' || iceState === 'new') return 'ice-checking';
+			if (iceState === 'connected' || iceState === 'completed') {
+				anyIceDone = true;
+				continue;
+			}
+			// no reported iceState (Safari, reconstructed Firefox transport):
+			// a succeeded selected pair proves the ICE side done
+			if (iceState === undefined && transport.getSelectedCandidatePair()?.state === 'succeeded') {
+				anyIceDone = true;
+			}
+		}
+
+		return anyIceDone ? 'dtls' : 'unknown';
+	}
+
+	private _sortedBySeverity() {
+		const severity: Record<string, number> = {
+			failed: 6, disconnected: 5, checking: 4, new: 3, connected: 2, completed: 1, closed: 0,
+		};
+
+		return [ ...(this.peerConnection.iceTransports ?? []) ].sort(
+			(a, b) => (severity[b.iceState ?? ''] ?? -1) - (severity[a.iceState ?? ''] ?? -1)
+		);
+	}
 }
+
+/** Which stage of establishment a too-long `connecting` is actually stuck in. */
+export type LongPcConnectionEstablishmentStage = 'ice-gathering' | 'ice-checking' | 'dtls' | 'unknown';

--- a/src/detectors/MediaPipelineDetector.ts
+++ b/src/detectors/MediaPipelineDetector.ts
@@ -1,4 +1,5 @@
 import { PeerConnectionMonitor } from "../monitors/PeerConnectionMonitor";
+import { attributeRtpToTransport } from "../utils/common";
 import { Detector } from "./Detector";
 
 /**
@@ -160,8 +161,8 @@ export class MediaPipelineDetector implements Detector {
 			seenTransports.add(transport.id);
 
 			const state = this._getState(this._demuxStates, transport.id);
-			const inboundRtps = this.peerConnection.inboundRtps.filter(
-				(inboundRtp) => inboundRtp.transportId === undefined || inboundRtp.transportId === transport.id
+			const inboundRtps = attributeRtpToTransport(
+				this.peerConnection.inboundRtps, transport.id, this.peerConnection.iceTransports.length,
 			);
 			const receivingBitrate = transport.receivingBitrate;
 			let demuxedDelta: number | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,13 @@ export { StuckDecoderDetector } from './detectors/StuckDecoderDetector';
 export type { StuckDecoderIssuePayload, StuckDecoderVariant } from './detectors/StuckDecoderDetector';
 export { IceConnectivityDetector } from './detectors/IceConnectivityDetector';
 export { BlockedTransportDetector } from './detectors/BlockedTransportDetector';
+export { DtlsHandshakeDetector } from './detectors/DtlsHandshakeDetector';
+export type {
+    DtlsIceEvidence,
+    DtlsHandshakeFailedIssuePayload,
+    DtlsHandshakeStalledIssuePayload,
+} from './detectors/DtlsHandshakeDetector';
+export type { LongPcConnectionEstablishmentStage } from './detectors/LongPcConnectionEstablishment';
 export type {
     BlockedTransportEvidence,
     BlockedTransportIssuePayload,

--- a/src/monitors/IceTransportMonitor.ts
+++ b/src/monitors/IceTransportMonitor.ts
@@ -1,4 +1,5 @@
 import { IceTransportStats } from "../schema/ClientSample";
+import { positiveDelta } from "../utils/common";
 import { PeerConnectionMonitor } from "./PeerConnectionMonitor";
 
 export class IceTransportMonitor implements IceTransportStats {
@@ -31,6 +32,14 @@ export class IceTransportMonitor implements IceTransportStats {
 	deltaBytesReceived?: number | undefined;
 	sendingBitrate?: number | undefined;
 	receivingBitrate?: number | undefined;
+	/**
+	 * How many times the browser switched the selected candidate pair since the
+	 * previous tick, from the native `selectedCandidatePairChanges` counter
+	 * (Chrome 80+, Firefox 155+; absent on Safari). `undefined` until the
+	 * transport has had a selection: the spec counter also increments on the
+	 * very first none → some selection, which is not churn.
+	 */
+	deltaSelectedCandidatePairChanges?: number | undefined;
 
 	/**
 	 * Additional data attached to this stats, will be shipped to the server
@@ -68,6 +77,16 @@ export class IceTransportMonitor implements IceTransportStats {
 		return this._peerConnection.mappedIceCandidatePairMonitors.get(this.selectedCandidatePairId ?? '');
 	}
 
+	/**
+	 * The live `SelectedIcePath` of this transport, when one exists. Paths are
+	 * keyed by the candidate pair's `pathKey`, which is the transport id for
+	 * every native flow, so this resolves for anything but the pathless
+	 * legacy fallbacks.
+	 */
+	public getSelectedIcePath() {
+		return this._peerConnection.mappedSelectedIcePaths.get(this.id);
+	}
+
 	public accept(stats: Omit<IceTransportStats, 'appData'>): void {
 		this._visited = true;
 
@@ -103,10 +122,51 @@ export class IceTransportMonitor implements IceTransportStats {
 			this.receivingBitrate = undefined;
 		}
 
+		// Only counted once the transport already had a selection: the spec counter
+		// also increments going from no selected pair to having one (its very first
+		// selection), and treating that as a switch would read every connection
+		// setup as churn. A backwards counter (reset) yields `undefined`, never 0.
+		this.deltaSelectedCandidatePairChanges = this.selectedCandidatePairId !== undefined
+			? positiveDelta(stats.selectedCandidatePairChanges, this.selectedCandidatePairChanges)
+			: undefined;
+
 		Object.assign(this, stats);
 	}
 
 	public createSample(): IceTransportStats {
+		// Constant after the handshake, so re-sending them every sample carries no
+		// information: they are emitted in the first sample and again only when one
+		// of them changes (the ufrag changes exactly at an ICE restart — a change
+		// worth seeing). `sendIceTransportMetadataOnChangeOnly: false` restores the
+		// legacy every-sample emission.
+		const staticMetadata: Pick<IceTransportStats,
+			'iceRole' | 'iceLocalUsernameFragment' | 'localCertificateId' | 'remoteCertificateId'
+			| 'tlsVersion' | 'dtlsCipher' | 'dtlsRole' | 'srtpCipher'> = {
+			iceRole: this.iceRole,
+			iceLocalUsernameFragment: this.iceLocalUsernameFragment,
+			localCertificateId: this.localCertificateId,
+			remoteCertificateId: this.remoteCertificateId,
+			tlsVersion: this.tlsVersion,
+			dtlsCipher: this.dtlsCipher,
+			dtlsRole: this.dtlsRole,
+			srtpCipher: this.srtpCipher,
+		};
+
+		let sampledStaticMetadata: typeof staticMetadata | undefined = staticMetadata;
+
+		if (this._peerConnection.parent.config.sendIceTransportMetadataOnChangeOnly) {
+			const fingerprint = [
+				this.iceRole, this.iceLocalUsernameFragment, this.localCertificateId, this.remoteCertificateId,
+				this.tlsVersion, this.dtlsCipher, this.dtlsRole, this.srtpCipher,
+			].join('|');
+
+			if (this._sampledStaticMetadataFingerprint === fingerprint) {
+				sampledStaticMetadata = undefined;
+			} else {
+				this._sampledStaticMetadataFingerprint = fingerprint;
+			}
+		}
+
 		return {
 			id: this.id,
 			timestamp: this.timestamp,
@@ -114,22 +174,17 @@ export class IceTransportMonitor implements IceTransportStats {
 			packetsReceived: this.packetsReceived,
 			bytesSent: this.bytesSent,
 			bytesReceived: this.bytesReceived,
-			iceRole: this.iceRole,
-			iceLocalUsernameFragment: this.iceLocalUsernameFragment,
 			dtlsState: this.dtlsState,
 			iceState: this.iceState,
 			selectedCandidatePairId: this.selectedCandidatePairId,
-			localCertificateId: this.localCertificateId,
-			remoteCertificateId: this.remoteCertificateId,
-			tlsVersion: this.tlsVersion,
-			dtlsCipher: this.dtlsCipher,
-			dtlsRole: this.dtlsRole,
-			srtpCipher: this.srtpCipher,
 			selectedCandidatePairChanges: this.selectedCandidatePairChanges,
 			ccfbMessagesSent: this.ccfbMessagesSent,
 			ccfbMessagesReceived: this.ccfbMessagesReceived,
 			attachments: this.attachments,
+			...(sampledStaticMetadata ?? {}),
 		};
 	}
+
+	private _sampledStaticMetadataFingerprint?: string;
 
 }

--- a/src/monitors/InboundRtpMonitor.ts
+++ b/src/monitors/InboundRtpMonitor.ts
@@ -357,6 +357,10 @@ export class InboundRtpMonitor implements InboundRtpStats {
 		return this._peerConnection.mappedIceTransportMonitors.get(this.transportId ?? '');
 	}
 
+	public getSelectedCandidatePair() {
+		return this.getIceTransport()?.getSelectedCandidatePair();
+	}
+
 	public getCodec() {
 		return this._peerConnection.mappedCodecMonitors.get(this.codecId ?? '');
 	}

--- a/src/monitors/OutboundRtpMonitor.ts
+++ b/src/monitors/OutboundRtpMonitor.ts
@@ -152,6 +152,14 @@ export class OutboundRtpMonitor implements OutboundRtpStats {
 		return this._peerConnection.mappedRemoteInboundRtpMonitors.get(this.ssrc);
 	}
 
+	public getIceTransport() {
+		return this._peerConnection.mappedIceTransportMonitors.get(this.transportId ?? '');
+	}
+
+	public getSelectedCandidatePair() {
+		return this.getIceTransport()?.getSelectedCandidatePair();
+	}
+
 	public getCodec() {
 		return this._peerConnection.mappedCodecMonitors.get(this.codecId ?? '');
 	}

--- a/src/monitors/PeerConnectionMonitor.ts
+++ b/src/monitors/PeerConnectionMonitor.ts
@@ -24,10 +24,12 @@ import { CalculatedScore } from "../scores/CalculatedScore";
 import { IceTupleChangeDetector } from "../detectors/IceTupleChangeDetector";
 import { IceConnectivityDetector } from "../detectors/IceConnectivityDetector";
 import { BlockedTransportDetector } from "../detectors/BlockedTransportDetector";
+import { DtlsHandshakeDetector } from "../detectors/DtlsHandshakeDetector";
 import { NoAvailableIceCandidateDetector } from "../detectors/NoAvailableIceCandidateDetector";
 import { MediaPipelineDetector } from "../detectors/MediaPipelineDetector";
 import { StatsCollector } from "../collectors/StatsCollector";
 import { StatsAdapters } from "../adapters/StatsAdapters";
+import { attributeRtpToTransport } from "../utils/common";
 import { SelectedIcePath } from "./SelectedIcePath";
 import { sampledScoreReasons } from "../scores/utils";
 import {
@@ -195,6 +197,9 @@ export class PeerConnectionMonitor extends EventEmitter<PeerConnectionMonitorEve
 		}
 		if (parent.config.blockedTransportDetector !== null) {
 			this.detectors.add(new BlockedTransportDetector(this));
+		}
+		if (parent.config.dtlsHandshakeDetector !== null) {
+			this.detectors.add(new DtlsHandshakeDetector(this));
 		}
 		if (parent.config.noAvailableIceCandidateDetector !== null) {
 			this.detectors.add(new NoAvailableIceCandidateDetector(this));
@@ -457,7 +462,10 @@ export class PeerConnectionMonitor extends EventEmitter<PeerConnectionMonitorEve
 		// assembled from signals belonging to two different candidates.
 		this.usingTCP = selectedIceCandidatePairs.some(pair => pair.usingTcp);
 		this.usingTURN = selectedIceCandidatePairs.some(pair => pair.usingTurn);
-		this.iceState = selectedIceCandidatePairs?.[0]?.getIceTransport()?.iceState as W3C.RtcIceTransportState;
+		// The most severe state across the transports: with BUNDLE there is exactly
+		// one, and without it a failed transport must not be masked by a healthy
+		// sibling that happened to be listed first.
+		this.iceState = this._mostSevereIceState();
 
 		this.totalDataChannelBytesReceived += this.deltaDataChannelBytesReceived;
 		this.totalDataChannelBytesSent += this.deltaDataChannelBytesSent;
@@ -608,6 +616,44 @@ export class PeerConnectionMonitor extends EventEmitter<PeerConnectionMonitorEve
 	public get selectedIceCandidatePairs() {
 		return this.iceTransports.map(iceTransport => iceTransport.getSelectedCandidatePair())
 		.filter(pair => pair !== undefined) as IceCandidatePairMonitor[];
+	}
+
+	/**
+	 * The RTP monitors that belong to `transport` — the bound convenience over
+	 * the single attribution rule in `utils/common.attributeRtpToTransport`.
+	 */
+	public attributeRtpToTransport<T extends { transportId?: string }>(
+		rtps: T[],
+		transport: IceTransportMonitor,
+	): T[] {
+		return attributeRtpToTransport(rtps, transport.id, this.mappedIceTransportMonitors.size);
+	}
+
+	/** Severity used to fold several transports' ICE states into one pc-level state. */
+	private static readonly ICE_STATE_SEVERITY: Record<string, number> = {
+		failed: 6,
+		disconnected: 5,
+		checking: 4,
+		new: 3,
+		connected: 2,
+		completed: 1,
+		closed: 0,
+	};
+
+	private _mostSevereIceState(): W3C.RtcIceTransportState | undefined {
+		let worst: string | undefined;
+
+		for (const transport of this.mappedIceTransportMonitors.values()) {
+			const state = transport.iceState;
+
+			if (state === undefined) continue;
+			if (worst === undefined
+				|| (PeerConnectionMonitor.ICE_STATE_SEVERITY[worst] ?? -1) < (PeerConnectionMonitor.ICE_STATE_SEVERITY[state] ?? -1)) {
+				worst = state;
+			}
+		}
+
+		return worst as W3C.RtcIceTransportState | undefined;
 	}
 
 	public set connectionState(state: W3C.RtcPeerConnectionState | undefined) {

--- a/src/monitors/RemoteInboundRtpMonitor.ts
+++ b/src/monitors/RemoteInboundRtpMonitor.ts
@@ -87,6 +87,14 @@ export class RemoteInboundRtpMonitor implements RemoteInboundRtpStats {
 		return this._peerConnection.mappedCodecMonitors.get(this.codecId ?? '');
 	}
 
+	public getIceTransport() {
+		return this._peerConnection.mappedIceTransportMonitors.get(this.transportId ?? '');
+	}
+
+	public getSelectedCandidatePair() {
+		return this.getIceTransport()?.getSelectedCandidatePair();
+	}
+
 	public accept(stats: Omit<RemoteInboundRtpStats, 'appData'>): void {
 		this._visited = true;
 

--- a/src/monitors/RemoteOutboundRtpMonitor.ts
+++ b/src/monitors/RemoteOutboundRtpMonitor.ts
@@ -65,6 +65,14 @@ export class RemoteOutboundRtpMonitor implements RemoteOutboundRtpStats {
 		return this._peerConnection.mappedCodecMonitors.get(this.codecId ?? '');
 	}
 
+	public getIceTransport() {
+		return this._peerConnection.mappedIceTransportMonitors.get(this.transportId ?? '');
+	}
+
+	public getSelectedCandidatePair() {
+		return this.getIceTransport()?.getSelectedCandidatePair();
+	}
+
 	public accept(stats: Omit<RemoteOutboundRtpStats, 'appData'>): void {
 		this._visited = true;
 

--- a/src/monitors/SelectedIcePath.ts
+++ b/src/monitors/SelectedIcePath.ts
@@ -414,10 +414,10 @@ export class SelectedIcePath extends EventEmitter<SelectedIcePathEvents> {
 			payload: {
 				peerConnectionId: this._peerConnection.peerConnectionId,
 				transition,
-				// schema 3.5.0 payloads are flat records of primitives: the
-				// path evidence objects travel as JSON documents
-				from: from === undefined ? undefined : JSON.stringify(from),
-				to: JSON.stringify(to),
+				// schema 3.7.0 payloads may nest: the path evidence travels as
+				// structured records, no longer as pre-serialised JSON strings
+				from,
+				to,
 			},
 		});
 	}

--- a/src/schema/ClientEventTypes.ts
+++ b/src/schema/ClientEventTypes.ts
@@ -1,11 +1,13 @@
 /* eslint-disable no-shadow */
 
 /**
- * The shape schema 3.5.0 allows for every client event payload: a flat record
- * of primitives. `null`/`undefined` entries are legal on the API (DOM types
- * produce them); `undefined` keys disappear when the sample serialises.
+ * The shape schema 3.7.0 allows for every client event payload: a record that
+ * may carry nested structures, not only flat primitives — but always a record
+ * on the wire, never a pre-serialised JSON string. `null`/`undefined` entries
+ * are legal on the API (DOM types produce them); `undefined` keys disappear
+ * when the sample serialises.
  */
-export type ClientEventPayloadRecord = Record<string, boolean | string | number | null | undefined>;
+export type ClientEventPayloadRecord = Record<string, unknown>;
 
 
 export enum ClientEventTypes {
@@ -289,10 +291,17 @@ export interface PeerConnectionIcePathChangedEventPayload extends ClientEventPay
 	peerConnectionId: string;
 	/** Why the path changed: 'initial-selection', 'direct-to-relay', ... */
 	transition: string;
-	/** The previous path evidence as a JSON document. Absent for the first path observed on a transport. */
-	from?: string;
-	/** The path evidence that is selected now, as a JSON document. */
-	to: string;
+	/**
+	 * The previous path evidence as a structured record (a pre-serialised JSON
+	 * string before schema 3.7.0). Absent for the first path observed on a
+	 * transport.
+	 */
+	from?: Record<string, string | number | boolean | undefined>;
+	/**
+	 * The path evidence that is selected now, as a structured record (a
+	 * pre-serialised JSON string before schema 3.7.0).
+	 */
+	to: Record<string, string | number | boolean | undefined>;
 }
 
 export interface IceRestartEventPayload extends ClientEventPayloadRecord {
@@ -310,6 +319,19 @@ export interface IceRestartEventPayload extends ClientEventPayloadRecord {
 export interface LongPcConnectionEstablishmentEventPayload extends ClientEventPayloadRecord {
 	peerConnectionId: string;
 	duration: number;
+	/**
+	 * Which stage of establishment the connection is actually stuck in:
+	 * 'ice-gathering', 'ice-checking', 'dtls' or 'unknown'. `connectionState:
+	 * 'connecting'` covers ICE and the DTLS handshake alike — this names which
+	 * of them is holding the connection up. Since schema 3.7.0.
+	 */
+	stalledStage?: string;
+	/** ICE state of the most severe transport at raise time. Since schema 3.7.0. */
+	iceState?: string;
+	/** DTLS state of the most severe transport at raise time. Since schema 3.7.0. */
+	dtlsState?: string;
+	/** The peer connection's ICE gathering state at raise time. Since schema 3.7.0. */
+	iceGatheringState?: string;
 }
 
 export interface ExcessiveSynthesizedAudioEventPayload extends ClientEventPayloadRecord {

--- a/src/schema/ClientSample.ts
+++ b/src/schema/ClientSample.ts
@@ -1,5 +1,5 @@
 
-export const schemaVersion = "3.6.0";
+export const schemaVersion = "3.7.0";
 
 /**
 * The WebRTC app provided custom stats payload
@@ -13,7 +13,7 @@ export type ExtensionStat = {
 	/**
 	* The payload of the extension stats the custom app provides
 	*/
-	payload?: Record<string, boolean | string | number>;
+	payload?: Record<string, unknown>;
 
 }
 
@@ -29,7 +29,7 @@ export type ClientMetaData = {
 	/**
 	* The attributes of the meta data entry, if applicable.
 	*/
-	payload?: Record<string, boolean | string | number>;
+	payload?: Record<string, unknown>;
 
 	/**
 	* The unique identifier of the peer connection for which the event was generated.
@@ -70,7 +70,7 @@ export type ClientIssue = {
 	/**
 	* The attributes of the issue, if applicable.
 	*/
-	payload?: Record<string, boolean | string | number>;
+	payload?: Record<string, unknown>;
 
 	/**
 	* The timestamp in epoch format when the event was generated.
@@ -91,7 +91,7 @@ export type ClientEvent = {
 	/**
 	* The attributes of the event, if applicable.
 	*/
-	payload?: Record<string, boolean | string | number>;
+	payload?: Record<string, unknown>;
 
 	/**
 	* The timestamp in epoch format when the event was generated.
@@ -360,6 +360,18 @@ export type IceCandidateStats = {
 
 /**
 * ICE Transport Stats
+*
+* Payload expectation since schema 3.7.0: the mostly-static members —
+* `iceRole`, `iceLocalUsernameFragment`, `localCertificateId`,
+* `remoteCertificateId`, `tlsVersion`, `dtlsCipher`, `dtlsRole`,
+* `srtpCipher` — are shipped in a transport's first sample and again only
+* when one of their values changes (the ufrag changing is exactly an ICE
+* restart). Consumers keep the last seen value per transport `id`; absence
+* in a sample means "unchanged", not "unknown". The client config
+* `sendIceTransportMetadataOnChangeOnly: false` restores every-sample
+* emission. Dynamic members (`iceState`, `dtlsState`,
+* `selectedCandidatePairId`, `selectedCandidatePairChanges`, byte/packet
+* counters) are shipped every sample as before.
 */
 export type IceTransportStats = {
 	/**

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -88,3 +88,29 @@ export function positiveDelta(current?: number, previous?: number): number | und
 export function maxTickGapInMs(collectingPeriodInMs: number): number {
 	return Math.max(collectingPeriodInMs * 3, 15_000);
 }
+
+/**
+ * The single RTP-to-transport attribution rule: streams attribute to a
+ * transport by their explicit `transportId`; streams carrying none (older
+ * browsers, exotic stacks) attribute to the transport only when it is the peer
+ * connection's sole transport — exact under BUNDLE, and never counted twice
+ * when a connection without BUNDLE has several transports.
+ *
+ * Every consumer that maps RTP streams onto a transport must go through this,
+ * so two detectors can never disagree about which transport a stream belongs
+ * to. `PeerConnectionMonitor.attributeRtpToTransport` is the bound
+ * convenience over it.
+ */
+export function attributeRtpToTransport<T extends { transportId?: string }>(
+	rtps: T[],
+	transportId: string,
+	transportCount: number,
+): T[] {
+	const attributed = rtps.filter((rtp) => rtp.transportId === transportId);
+
+	if (0 < attributed.length) return attributed;
+
+	return transportCount === 1
+		? rtps.filter((rtp) => rtp.transportId === undefined)
+		: [];
+}

--- a/tests/adapters/FirefoxStatsAdapter.spec.ts
+++ b/tests/adapters/FirefoxStatsAdapter.spec.ts
@@ -228,7 +228,9 @@ describe('FirefoxStatsAdapter', () => {
 			expect(transport).toBeDefined();
 			expect(transport.id).toBe('T1');
 			expect(transport.selectedCandidatePairId).toBe('CP1');
-			expect(transport.selectedCandidatePairChanges).toBe(0);
+			// spec semantics: "initially zero", and none -> some also increments,
+			// so the very first selection lands on 1 like a native counter
+			expect(transport.selectedCandidatePairChanges).toBe(1);
 			expect(inbound.transportId).toBe(transport.id);
 		});
 
@@ -249,7 +251,7 @@ describe('FirefoxStatsAdapter', () => {
 			expect(transport.bytesReceived).toBe(4000);
 			expect(transport.packetsSent).toBe(20);
 			expect(transport.selectedCandidatePairId).toBe('CP2');
-			expect(transport.selectedCandidatePairChanges).toBe(1);
+			expect(transport.selectedCandidatePairChanges).toBe(2); // first selection + one switch
 		});
 
 		it('stays a no-op when a native transport report is present, wherever it appears', () => {

--- a/tests/detectors/DtlsHandshakeDetector.spec.ts
+++ b/tests/detectors/DtlsHandshakeDetector.spec.ts
@@ -1,0 +1,219 @@
+import { DtlsHandshakeDetector } from "../../src/detectors/DtlsHandshakeDetector";
+
+interface TestIssue {
+    id: string;
+    type: string;
+    key?: string;
+    payload: Record<string, unknown>;
+}
+
+class MockClientMonitor {
+    public config = {
+        collectingPeriodInMs: 2000,
+        dtlsHandshakeDetector: {
+            stalledThresholdInMs: 6000,
+        },
+    };
+
+    public readonly activeIssues = new Map<string, TestIssue>();
+    public readonly resolvedIssues: (TestIssue & { comment?: string })[] = [];
+    public readonly emitted: { name: string; payload: Record<string, unknown> }[] = [];
+    private nextId = 0;
+
+    emit(eventName: string, eventData: Record<string, unknown>) {
+        this.emitted.push({ name: eventName, payload: eventData });
+    }
+
+    raiseIssue(key: string, input: { type: string; payload?: Record<string, unknown> }) {
+        const issue: TestIssue = {
+            id: `iss_${this.nextId++}`,
+            type: input.type,
+            key,
+            payload: input.payload ?? {},
+        };
+        this.activeIssues.set(key, issue);
+        return issue;
+    }
+
+    resolveIssue(key: string, opts?: { comment?: string; payload?: Record<string, unknown> }) {
+        const found = this.activeIssues.get(key);
+        if (!found) return undefined;
+        this.activeIssues.delete(key);
+        const resolved = { ...found, payload: opts?.payload ?? found.payload, comment: opts?.comment };
+        this.resolvedIssues.push(resolved);
+        return resolved;
+    }
+
+    getIssuesByType(type: string) {
+        return [ ...this.activeIssues.values() ].filter(issue => issue.type === type);
+    }
+}
+
+class MockCandidatePair {
+    public state: string | undefined = 'succeeded';
+    public localCandidate: { usernameFragment?: string } = {};
+
+    getLocalCandidate() {
+        return this.localCandidate;
+    }
+}
+
+class MockIceTransport {
+    public selectedCandidatePairId: string | undefined = 'pair-1';
+    public iceLocalUsernameFragment: string | undefined = 'ufrag-1';
+
+    constructor(
+        public id: string,
+        public iceState: string | undefined,
+        public dtlsState: string | undefined,
+        private pair: MockCandidatePair | undefined = new MockCandidatePair(),
+    ) {}
+
+    getSelectedCandidatePair() {
+        return this.pair;
+    }
+}
+
+class MockPeerConnectionMonitor {
+    public peerConnectionId = 'test-pc-id';
+    public parent = new MockClientMonitor();
+    public closed = false;
+    public iceTransports: MockIceTransport[] = [];
+}
+
+describe('DtlsHandshakeDetector', () => {
+    let detector: DtlsHandshakeDetector;
+    let mockPeerConnection: MockPeerConnectionMonitor;
+    let mockClientMonitor: MockClientMonitor;
+    let transport: MockIceTransport;
+
+    /** Runs `count` detector ticks, each advancing the fake clock by 2s. */
+    const ticks = (count: number) => {
+        for (let i = 0; i < count; ++i) {
+            detector.update();
+            jest.advanceTimersByTime(2000);
+        }
+    };
+
+    beforeEach(() => {
+        mockPeerConnection = new MockPeerConnectionMonitor();
+        mockClientMonitor = mockPeerConnection.parent;
+        transport = new MockIceTransport('transport-1', 'connected', 'connecting');
+        mockPeerConnection.iceTransports = [ transport ];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        detector = new DtlsHandshakeDetector(mockPeerConnection as any);
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('dtls-handshake-failed', () => {
+        it('raises immediately on dtlsState failed', () => {
+            transport.dtlsState = 'failed';
+            ticks(1);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.FAILED_ISSUE_TYPE)).toHaveLength(1);
+            expect(mockClientMonitor.emitted.map(entry => entry.name)).toContain('dtls-handshake-failed');
+        });
+
+        it('raises once, not per tick', () => {
+            transport.dtlsState = 'failed';
+            ticks(5);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.FAILED_ISSUE_TYPE)).toHaveLength(1);
+        });
+
+        it('resolves when a later handshake connects (post ICE restart re-key)', () => {
+            transport.dtlsState = 'failed';
+            ticks(1);
+            transport.dtlsState = 'connected';
+            ticks(1);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.FAILED_ISSUE_TYPE)).toHaveLength(0);
+            expect(mockClientMonitor.resolvedIssues.some(issue => issue.type === DtlsHandshakeDetector.FAILED_ISSUE_TYPE)).toBe(true);
+        });
+    });
+
+    describe('dtls-handshake-stalled', () => {
+        it('raises when ICE is healthy and DTLS sits in connecting past the threshold', () => {
+            ticks(5); // first tick is maturity, stall timer starts on tick 2
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(1);
+        });
+
+        it('does not raise before the threshold', () => {
+            ticks(2);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+        });
+
+        it('never judges a transport on its first observed tick', () => {
+            // the threshold could only be met if the first tick armed the timer
+            mockClientMonitor.config.dtlsHandshakeDetector.stalledThresholdInMs = 0;
+            ticks(1);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+        });
+
+        it('does not raise while ICE itself is not proven healthy', () => {
+            transport.iceState = 'checking';
+            ticks(6);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+        });
+
+        it('proves ICE by the selected pair where the browser reports no iceState', () => {
+            transport.iceState = undefined; // Safari / reconstructed Firefox transport
+            ticks(5);
+
+            const [ issue ] = mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE);
+
+            expect(issue).toBeDefined();
+            expect(issue.payload.iceEvidence).toBe('selected-pair-succeeded');
+        });
+
+        it('stays quiet without iceState and without a succeeded pair', () => {
+            transport.iceState = undefined;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (transport.getSelectedCandidatePair() as any).state = 'in-progress';
+            ticks(6);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+        });
+
+        it('treats dtlsState closed as a shutdown, never a stall', () => {
+            transport.dtlsState = 'closed';
+            ticks(6);
+
+            expect(mockClientMonitor.activeIssues.size).toBe(0);
+        });
+
+        it('resolves when the handshake completes', () => {
+            ticks(5);
+            transport.dtlsState = 'connected';
+            ticks(1);
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+            expect(mockClientMonitor.resolvedIssues.some(issue => issue.type === DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toBe(true);
+        });
+
+        it('restarts the stall timer when the ICE username fragment changes (ICE restart)', () => {
+            ticks(3); // timer armed, threshold not yet met
+            transport.iceLocalUsernameFragment = 'ufrag-2'; // restart re-keys DTLS
+            ticks(2); // would have crossed the threshold on the old timer
+
+            expect(mockClientMonitor.getIssuesByType(DtlsHandshakeDetector.STALLED_ISSUE_TYPE)).toHaveLength(0);
+        });
+
+        it('resolves everything when the transport is gone', () => {
+            ticks(5);
+            mockPeerConnection.iceTransports = [];
+            ticks(1);
+
+            expect(mockClientMonitor.activeIssues.size).toBe(0);
+            expect(mockClientMonitor.resolvedIssues.some(issue => issue.comment === 'ice transport is gone')).toBe(true);
+        });
+    });
+});

--- a/tests/utils/attributeRtpToTransport.spec.ts
+++ b/tests/utils/attributeRtpToTransport.spec.ts
@@ -1,0 +1,42 @@
+import { attributeRtpToTransport } from "../../src/utils/common";
+
+describe('attributeRtpToTransport', () => {
+    const rtp = (transportId?: string) => ({ transportId });
+
+    it('attributes by exact transportId match', () => {
+        const streams = [ rtp('T1'), rtp('T2'), rtp('T1') ];
+
+        expect(attributeRtpToTransport(streams, 'T1', 2)).toHaveLength(2);
+        expect(attributeRtpToTransport(streams, 'T2', 2)).toHaveLength(1);
+    });
+
+    it('attributes transportId-less streams to a sole transport (exact under BUNDLE)', () => {
+        const streams = [ rtp(undefined), rtp(undefined) ];
+
+        expect(attributeRtpToTransport(streams, 'T1', 1)).toHaveLength(2);
+    });
+
+    it('never attributes transportId-less streams when several transports exist', () => {
+        // this is the double-counting case the shared rule exists to prevent:
+        // the same unattributed stream must not be counted against both transports
+        const streams = [ rtp(undefined) ];
+
+        expect(attributeRtpToTransport(streams, 'T1', 2)).toHaveLength(0);
+        expect(attributeRtpToTransport(streams, 'T2', 2)).toHaveLength(0);
+    });
+
+    it('prefers exact matches over the sole-transport fallback', () => {
+        const streams = [ rtp('T1'), rtp(undefined) ];
+
+        const attributed = attributeRtpToTransport(streams, 'T1', 1);
+
+        expect(attributed).toHaveLength(1);
+        expect(attributed[0].transportId).toBe('T1');
+    });
+
+    it('returns nothing for a transport no stream names when exact matches exist elsewhere', () => {
+        const streams = [ rtp('T1') ];
+
+        expect(attributeRtpToTransport(streams, 'T2', 2)).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Schema ClientSample 3.7.0:
- payloads may nest: ClientEvent/ClientIssue/ClientMetaData/ExtensionStat payloads are Record<string, unknown>; ClientPayloadValue removed
- PEER_CONNECTION_ICE_PATH_CHANGED ships structured from/to records instead of pre-serialised JSON strings
- IceTransportStats static members (roles, ciphers, ufrag, cert refs) ship on change only; absence means unchanged (sendIceTransportMetadataOnChangeOnly, default true)

Transport observability:
- single RTP→transport attribution rule shared by BlockedTransport and MediaPipeline detectors (fixes double-counting without BUNDLE)
- getIceTransport()/getSelectedCandidatePair() on all four RTP monitors
- pc-level iceState = most severe across transports
- deltaSelectedCandidatePairChanges wired into unstable-ice-path, restart-suppressed; Firefox <153 synthetic counter spec-aligned
- new DtlsHandshakeDetector: dtls-handshake-failed / dtls-handshake-stalled
- LONG_PC_CONNECTION_ESTABLISHMENT names the stuck stage (ice-gathering / ice-checking / dtls)