### PR TITLE
test: show that data reported before the first subscriber is lost

### DIFF
--- a/tests/SampleLossBeforeFirstSubscriber.spec.ts
+++ b/tests/SampleLossBeforeFirstSubscriber.spec.ts
@@ -1,0 +1,189 @@
+import { ClientMonitor } from "../src/ClientMonitor";
+import { ClientSample } from "../src/schema/ClientSample";
+import { Logger } from "../src/utils/logger";
+
+/**
+ * `createSample()` builds a sample, clears the four buffers it drained, and only
+ * then emits `'sample-created'`. Before any listener subscribes that emit reaches
+ * nobody, and nothing re-queues the sample — so everything reported between
+ * construction and the first subscriber is lost.
+ *
+ * The disabled cases below describe what a consumer that subscribes late should
+ * receive. They assert *what is delivered*, never how many samples carry it, so
+ * they hold for any fix that stops discarding the data. A fix enables them.
+ *
+ * The one enabled case is the opposite: it passes today and locks in the
+ * behaviour a fix must not disturb.
+ */
+
+const silentLogger: Logger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createMonitor(config: Record<string, unknown> = {}) {
+	return new ClientMonitor({
+		logger: silentLogger,
+		integrateNavigatorMediaDevices: false,
+		addClientJointEventOnCreated: false,
+		addClientLeftEventOnClose: false,
+		watchTabVisibility: false,
+		...config,
+	});
+}
+
+const TAG_PREFIX = 'test-tag:';
+
+function addTag(monitor: ClientMonitor, tag: string) {
+	monitor.addMetaData({ type: `${TAG_PREFIX}${tag}` });
+}
+
+/** Everything tagged that reached the consumer, in delivery order. */
+function deliveredTags(samples: ClientSample[]) {
+	return samples.flatMap(sample =>
+		(sample.clientMetaItems ?? [])
+			.filter(item => item.type.startsWith(TAG_PREFIX))
+			.map(item => item.type.slice(TAG_PREFIX.length))
+	);
+}
+
+function deliveredMetaTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientMetaItems ?? []).map(item => item.type));
+}
+
+function deliveredEventTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientEvents ?? []).map(event => event.type));
+}
+
+function collect(monitor: ClientMonitor) {
+	const received: ClientSample[] = [];
+
+	monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+	return received;
+}
+
+describe('data reported before the first `sample-created` subscriber', () => {
+	xit('reaches a consumer that subscribes afterwards', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	xit('includes client events, not only meta data', () => {
+		const monitor = createMonitor();
+
+		monitor.addEvent({ type: 'EARLY_EVENT' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredEventTypes(received)).toContain('EARLY_EVENT');
+
+		monitor.close();
+	});
+
+	xit('includes the user agent data the constructor collects', () => {
+		// The clearest case: no caller is involved at all. The constructor calls
+		// `fetchUserAgentData()`, so a consumer subscribing after the first
+		// sampling tick never learns the browser it is running in.
+		const monitor = createMonitor();
+
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredMetaTypes(received)).toContain('USER_AGENT_DATA');
+
+		monitor.close();
+	});
+
+	xit('keeps the order it was reported in', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		addTag(monitor, 'third');
+		monitor.createSample();
+
+		expect(deliveredTags(received)).toEqual(['first', 'second', 'third']);
+
+		monitor.close();
+	});
+
+	xit('is delivered once, however many consumers subscribe', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+		const second: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => second.push(sample));
+
+		expect(deliveredTags(received)).toEqual(['first']);
+		expect(deliveredTags(second)).toEqual([]);
+
+		monitor.close();
+	});
+
+	xit('reaches a consumer that subscribes through `once`', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.once('sample-created', ({ sample }) => received.push(sample));
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	xit('reaches a consumer that subscribes through the `onsamplecreated` setter', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.onsamplecreated = ({ sample }) => received.push(sample);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+});
+
+describe('a consumer subscribed from the start', () => {
+	// Enabled: this passes today, and a fix for the cases above must not change
+	// it. Nothing is withheld, replayed, or reordered for a consumer that was
+	// always there.
+	it('receives every sample once, in order, with nothing replayed', () => {
+		const monitor = createMonitor();
+		const received = collect(monitor);
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		expect(received).toHaveLength(2);
+		expect(deliveredTags(received)).toEqual(['first', 'second']);
+
+		monitor.close();
+	});
+});


### PR DESCRIPTION
## The problem

`createSample()` builds a sample, clears the four buffers it drained, and only then emits `'sample-created'`:

```js
const clientSample = { /* … */ clientEvents: this._clientEvents, clientMetaItems: this._clientMetaItems, /* … */ };
this._clientEvents = []; this._clientMetaItems = []; this._clientIssues = []; this._extensionStats = [];
return clientSample ? (this.emit('sample-created', { clientMonitor: this, sample: clientSample }), /* … */) : undefined;
```

Before any listener subscribes, that emit reaches nobody and nothing re-queues the sample. Everything reported between construction and the first subscriber is discarded — including the `USER_AGENT_DATA` the constructor itself collects via `Sources.fetchUserAgentData()`, which no caller is involved in at all.

`bufferingEventsForSamples` does not cover this. Per its own docstring it decides whether items are *accepted while sampling is off*:

```js
if (!this._samplingTick && !this.config.bufferingEventsForSamples) return;
```

With sampling on, that guard never trips: items are accepted, then discarded by the next `createSample()`.

## What this PR does

Adds `tests/SampleLossBeforeFirstSubscriber.spec.ts`. Seven cases describe what a consumer subscribing late should receive. **They are disabled (`xit`) because they fail on `master`** — enabling them belongs with a fix. Switch `xit` to `it` to see it:

```
● includes the user agent data the constructor collects
  Expected value: "USER_AGENT_DATA"
  Received array: []
```

They assert *what is delivered*, never how many samples carry it, so they hold for any fix that stops discarding the data rather than presupposing a particular one.

To watch them fail without editing the tracked file:

```bash
perl -pe 's/\bxit\(/it(/g' tests/SampleLossBeforeFirstSubscriber.spec.ts > tests/AllEnabled.spec.ts \
  && npx jest tests/AllEnabled.spec.ts --forceExit; rm -f tests/AllEnabled.spec.ts
```

```
✕ reaches a consumer that subscribes afterwards
✕ includes client events, not only meta data
✕ includes the user agent data the constructor collects
✕ keeps the order it was reported in
✕ is delivered once, however many consumers subscribe
✕ reaches a consumer that subscribes through `once`
✕ reaches a consumer that subscribes through the `onsamplecreated` setter
✓ receives every sample once, in order, with nothing replayed

Tests: 7 failed, 1 passed, 8 total
```

Two notes on that command, both learned the hard way: `--forceExit` is needed because a failing assertion never reaches `monitor.close()`, so the collect timer keeps the process alive and jest hangs; and BSD `sed` has no `\b`, so `sed 's/\bxit(/it(/'` silently matches nothing and reports "7 skipped" instead.

An eighth case is enabled and passes today. It pins what a fix must not disturb: a consumer subscribed from the start still receives every sample once, in order, with nothing replayed.

## Why this is separate from the fix

So the problem is reviewable on its own, and so the fix can be seen turning failing tests green.

Two candidate fixes follow as separate PRs; whichever you prefer enables these cases. **If you would rather not carry disabled tests on `master`, say so and I will squash this into the fix you choose.**
