### PR TITLE
fix: retain samples created before the first subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ const monitor = new ClientMonitor({
     addClientJointEventOnCreated: true, // Default: true
     addClientLeftEventOnClose: true, // Default: true
     bufferingEventsForSamples: false, // Default: false
+    maxRetainedSamplesBeforeFirstSubscriber: 32, // Default: 32
 
     // Detector configurations (all optional).
     //
@@ -1649,6 +1650,35 @@ monitor.on("sample-created", (sample) => {
     sendToAnalytics(sample);
 });
 ```
+
+### Subscribing Late
+
+Sampling starts with the monitor, not with the consumer. A `'sample-created'`
+listener that subscribes some time after construction — after an async import,
+after a signaling handshake — would otherwise miss every sample created before
+it existed, including the one carrying the user agent data the constructor
+collects.
+
+Samples created while nothing is listening are therefore retained and replayed,
+in creation order, to the first listener that subscribes:
+
+```javascript
+const monitor = new ClientMonitor({ samplingPeriodInMs: 4000 });
+
+// ...minutes later, once the analytics transport is ready
+monitor.on("sample-created", ({ sample }) => sendToAnalytics(sample));
+// every sample created before this line arrives here first, oldest first
+```
+
+Each retained sample keeps its own `timestamp` and still bounds its own time
+window — nothing is merged into an oversized first sample. The queue holds
+`maxRetainedSamplesBeforeFirstSubscriber` samples (default 32, a little over
+four minutes at the default sampling period) and drops the oldest beyond that,
+logging an error naming how many were lost. Set it to `0` to discard
+unconsumed samples instead of retaining them.
+
+A consumer that subscribes immediately after construction is unaffected: the
+queue is always empty and each sample is emitted exactly once, as before.
 
 ### Manual Sampling
 

--- a/src/ClientMonitor.ts
+++ b/src/ClientMonitor.ts
@@ -37,6 +37,14 @@ import { ClientEventPayloadProvider } from './sources/ClientEventPayloadProvider
 
 const MODULE_NAME = 'ClientMonitor';
 
+/**
+ * Samples retained while nothing listens for `'sample-created'`. At the default
+ * 8s sampling period this covers a little over four minutes of monitor lifetime
+ * before the oldest sample is dropped, which is far longer than any consumer
+ * should need to attach.
+ */
+const DEFAULT_MAX_RETAINED_SAMPLES_BEFORE_FIRST_SUBSCRIBER = 32;
+
 export type ExtensionStatProvider = () => { type: string, payload?: ClientPayload } | Promise<{ type: string, payload?: ClientPayload }>;
 export class ClientMonitor<AppData extends Record<string, unknown> = Record<string, unknown>> extends EventEmitter<ClientMonitorEvents> {
     public static readonly samplingSchemaVersion = schemaVersion;
@@ -106,6 +114,8 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
     private _clientMetaItems: ClientSampleClientMetaData[] = [];
     private _clientIssues: ClientSampleClientIssue[] = [];
     private _extensionStats: ExtensionStat[] = [];
+    private _retainedSamples: ClientSample[] = [];
+    private _droppedRetainedSamples = 0;
     public durationOfCollectingStatsInMs = 0;
     public readonly config: AppliedClientMonitorConfig<AppData>;
 
@@ -281,6 +291,8 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
                 iceRestartRecommendationCooldownInMs: 15000,
             }),
             bufferingEventsForSamples: monitorConfig.bufferingEventsForSamples ?? false,
+            maxRetainedSamplesBeforeFirstSubscriber: monitorConfig.maxRetainedSamplesBeforeFirstSubscriber
+                ?? DEFAULT_MAX_RETAINED_SAMPLES_BEFORE_FIRST_SUBSCRIBER,
             sendResolvedIssuesToServer: monitorConfig.sendResolvedIssuesToServer ?? true,
             sendScoreReasonsToServer: monitorConfig.sendScoreReasonsToServer ?? true,
             sendIceTransportMetadataOnChangeOnly: monitorConfig.sendIceTransportMetadataOnChangeOnly ?? true,
@@ -396,18 +408,29 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
             this.createSample();
         }
 
+        if (0 < this._retainedSamples.length) {
+            // Kept rather than cleared: clearing would destroy the very samples
+            // retention exists to preserve, and a consumer subscribing after
+            // close still drains them. They are released with the monitor.
+            this.logger.warn(`[${MODULE_NAME}]:`,
+                `Closing with ${this._retainedSamples.length} sample(s) never delivered, because no 'sample-created' listener ever subscribed.`
+            );
+        }
+
         this.closed = true;
         this.emit('close');
     }
 
     public on<K extends keyof ClientMonitorEvents>(event: K, listener: (...args: ClientMonitorEvents[K]) => void): this {
         super.on(event, listener);
+        this._flushRetainedSamples();
 
         return this;
     }
 
     public once<K extends keyof ClientMonitorEvents>(event: K, listener: (...args: ClientMonitorEvents[K]) => void): this {
         super.once(event, listener);
+        this._flushRetainedSamples();
 
         return this;
     }
@@ -543,13 +566,70 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
         if (!clientSample) {
             return;
         }
-        this.emit('sample-created', {
-            clientMonitor: this,
-            sample: clientSample
-        });
+        if (this.listenerCount('sample-created') === 0) {
+            this._retainSample(clientSample);
+        } else {
+            // Also flushed from `on`/`once`; repeated here so a subscription
+            // made through a path that bypasses those overrides still replays
+            // the retained samples ahead of this one.
+            this._flushRetainedSamples();
+            this.emit('sample-created', {
+                clientMonitor: this,
+                sample: clientSample
+            });
+        }
         this.lastSampledAt = timestamp;
 
         return clientSample;
+    }
+
+    /**
+     * Holds a sample nobody could receive yet, dropping the oldest once the
+     * queue is full. The drop is an error rather than a warning: the queue is
+     * sized so that it cannot overflow in a session that ever attaches a
+     * consumer, so reaching it means samples are being permanently lost.
+     */
+    private _retainSample(clientSample: ClientSample): void {
+        const limit = this.config.maxRetainedSamplesBeforeFirstSubscriber
+            ?? DEFAULT_MAX_RETAINED_SAMPLES_BEFORE_FIRST_SUBSCRIBER;
+
+        if (limit < 1) return;
+
+        this._retainedSamples.push(clientSample);
+
+        const overflow = this._retainedSamples.length - limit;
+
+        if (overflow < 1) return;
+
+        this._retainedSamples.splice(0, overflow);
+        this._droppedRetainedSamples += overflow;
+
+        this.logger.error(`[${MODULE_NAME}]:`,
+            `Dropped ${this._droppedRetainedSamples} sample(s) created before any 'sample-created' listener subscribed. ` +
+            `No consumer has subscribed after ${limit} samples — subscribe earlier, or raise maxRetainedSamplesBeforeFirstSubscriber.`
+        );
+    }
+
+    /**
+     * Replays, in creation order, the samples created before the first
+     * `'sample-created'` listener existed.
+     */
+    private _flushRetainedSamples(): void {
+        if (this._retainedSamples.length === 0) return;
+        if (this.listenerCount('sample-created') === 0) return;
+
+        // Drained before emitting so a listener subscribing from inside its own
+        // handler re-enters here and finds nothing left to replay.
+        const retainedSamples = this._retainedSamples;
+
+        this._retainedSamples = [];
+
+        for (const sample of retainedSamples) {
+            this.emit('sample-created', {
+                clientMonitor: this,
+                sample,
+            });
+        }
     }
 
     public addPeerConnectionMonitor(peerConnectionMonitor: PeerConnectionMonitor): void {

--- a/src/ClientMonitorConfig.ts
+++ b/src/ClientMonitorConfig.ts
@@ -29,6 +29,32 @@ export type AppliedClientMonitorConfig<AppData extends Record<string, unknown> =
     bufferingEventsForSamples?: boolean,
 
     /**
+     * How many created samples are held back while there is no
+     * `'sample-created'` listener, and replayed in order to the first one that
+     * subscribes.
+     *
+     * Sampling starts with the monitor, not with the consumer: every sample
+     * created before a listener exists used to be emitted to an empty listener
+     * list with its buffers already drained, so client events, meta items,
+     * issues and extension stats reported in that window were lost — including
+     * the user agent data the constructor itself collects. Retained samples
+     * each keep their own `timestamp`, so replaying them preserves the time
+     * windows they bound; nothing is merged into an oversized first sample.
+     *
+     * The queue is bounded and drops the oldest sample beyond the limit,
+     * logging an error naming the total dropped — with a sensibly sized queue
+     * that should never happen, and when it does it means no consumer ever
+     * subscribed, or subscribed far too late. At the default sampling period
+     * the default limit covers a little over four minutes.
+     *
+     * Set to `0` to disable retention entirely and restore the previous
+     * behaviour (samples created before the first subscriber are discarded).
+     *
+     * DEFAULT: 32
+     */
+    maxRetainedSamplesBeforeFirstSubscriber?: number,
+
+    /**
      * Specifies the interval (in milliseconds) at which the observer calls
      * the added statsCollectors and pulls the stats.
      *

--- a/tests/SampleLossBeforeFirstSubscriber.spec.ts
+++ b/tests/SampleLossBeforeFirstSubscriber.spec.ts
@@ -1,0 +1,189 @@
+import { ClientMonitor } from "../src/ClientMonitor";
+import { ClientSample } from "../src/schema/ClientSample";
+import { Logger } from "../src/utils/logger";
+
+/**
+ * `createSample()` builds a sample, clears the four buffers it drained, and only
+ * then emits `'sample-created'`. Before any listener subscribes that emit reaches
+ * nobody, and nothing re-queues the sample — so everything reported between
+ * construction and the first subscriber is lost.
+ *
+ * The disabled cases below describe what a consumer that subscribes late should
+ * receive. They assert *what is delivered*, never how many samples carry it, so
+ * they hold for any fix that stops discarding the data. A fix enables them.
+ *
+ * The one enabled case is the opposite: it passes today and locks in the
+ * behaviour a fix must not disturb.
+ */
+
+const silentLogger: Logger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createMonitor(config: Record<string, unknown> = {}) {
+	return new ClientMonitor({
+		logger: silentLogger,
+		integrateNavigatorMediaDevices: false,
+		addClientJointEventOnCreated: false,
+		addClientLeftEventOnClose: false,
+		watchTabVisibility: false,
+		...config,
+	});
+}
+
+const TAG_PREFIX = 'test-tag:';
+
+function addTag(monitor: ClientMonitor, tag: string) {
+	monitor.addMetaData({ type: `${TAG_PREFIX}${tag}` });
+}
+
+/** Everything tagged that reached the consumer, in delivery order. */
+function deliveredTags(samples: ClientSample[]) {
+	return samples.flatMap(sample =>
+		(sample.clientMetaItems ?? [])
+			.filter(item => item.type.startsWith(TAG_PREFIX))
+			.map(item => item.type.slice(TAG_PREFIX.length))
+	);
+}
+
+function deliveredMetaTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientMetaItems ?? []).map(item => item.type));
+}
+
+function deliveredEventTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientEvents ?? []).map(event => event.type));
+}
+
+function collect(monitor: ClientMonitor) {
+	const received: ClientSample[] = [];
+
+	monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+	return received;
+}
+
+describe('data reported before the first `sample-created` subscriber', () => {
+	it('reaches a consumer that subscribes afterwards', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	it('includes client events, not only meta data', () => {
+		const monitor = createMonitor();
+
+		monitor.addEvent({ type: 'EARLY_EVENT' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredEventTypes(received)).toContain('EARLY_EVENT');
+
+		monitor.close();
+	});
+
+	it('includes the user agent data the constructor collects', () => {
+		// The clearest case: no caller is involved at all. The constructor calls
+		// `fetchUserAgentData()`, so a consumer subscribing after the first
+		// sampling tick never learns the browser it is running in.
+		const monitor = createMonitor();
+
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredMetaTypes(received)).toContain('USER_AGENT_DATA');
+
+		monitor.close();
+	});
+
+	it('keeps the order it was reported in', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		addTag(monitor, 'third');
+		monitor.createSample();
+
+		expect(deliveredTags(received)).toEqual(['first', 'second', 'third']);
+
+		monitor.close();
+	});
+
+	it('is delivered once, however many consumers subscribe', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+		const second: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => second.push(sample));
+
+		expect(deliveredTags(received)).toEqual(['first']);
+		expect(deliveredTags(second)).toEqual([]);
+
+		monitor.close();
+	});
+
+	it('reaches a consumer that subscribes through `once`', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.once('sample-created', ({ sample }) => received.push(sample));
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	it('reaches a consumer that subscribes through the `onsamplecreated` setter', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.onsamplecreated = ({ sample }) => received.push(sample);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+});
+
+describe('a consumer subscribed from the start', () => {
+	// Enabled: this passes today, and a fix for the cases above must not change
+	// it. Nothing is withheld, replayed, or reordered for a consumer that was
+	// always there.
+	it('receives every sample once, in order, with nothing replayed', () => {
+		const monitor = createMonitor();
+		const received = collect(monitor);
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		expect(received).toHaveLength(2);
+		expect(deliveredTags(received)).toEqual(['first', 'second']);
+
+		monitor.close();
+	});
+});

--- a/tests/SampleRetention.spec.ts
+++ b/tests/SampleRetention.spec.ts
@@ -1,0 +1,196 @@
+import { ClientMonitor } from "../src/ClientMonitor";
+import { ClientSample } from "../src/schema/ClientSample";
+import { Logger } from "../src/utils/logger";
+
+/**
+ * What retention adds on top of the contract in
+ * `SampleLossBeforeFirstSubscriber.spec.ts`: the early data arrives as the very
+ * samples that were created for it, each still bounding its own time window,
+ * rather than merged into one sample stamped when the consumer happened to
+ * subscribe. The queue that holds them is bounded, and says so when it overflows.
+ */
+
+const silentLogger: Logger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createRecordingLogger() {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+	const logger: Logger = {
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: (...args: unknown[]) => warnings.push(args.join(' ')),
+		error: (...args: unknown[]) => errors.push(args.join(' ')),
+	};
+
+	return { logger, errors, warnings };
+}
+
+function createMonitor(config: Record<string, unknown> = {}) {
+	return new ClientMonitor({
+		logger: silentLogger,
+		integrateNavigatorMediaDevices: false,
+		addClientJointEventOnCreated: false,
+		addClientLeftEventOnClose: false,
+		watchTabVisibility: false,
+		...config,
+	});
+}
+
+const TAG_PREFIX = 'test-tag:';
+
+/** Creates one sample carrying a meta item that names it. */
+function createTaggedSample(monitor: ClientMonitor, tag: string) {
+	monitor.addMetaData({ type: `${TAG_PREFIX}${tag}` });
+
+	return monitor.createSample();
+}
+
+/**
+ * The tags of a sample, ignoring the meta items the monitor adds on its own
+ * (the user agent data the constructor collects).
+ */
+function tagsOf(sample: ClientSample) {
+	return (sample.clientMetaItems ?? [])
+		.filter(item => item.type.startsWith(TAG_PREFIX))
+		.map(item => item.type.slice(TAG_PREFIX.length));
+}
+
+describe('samples created before the first subscriber', () => {
+
+	it('replays them in creation order, ahead of the samples created afterwards', () => {
+		const monitor = createMonitor();
+
+		createTaggedSample(monitor, 'first');
+		createTaggedSample(monitor, 'second');
+
+		const received: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+		createTaggedSample(monitor, 'third');
+
+		expect(received.map(tagsOf)).toEqual([['first'], ['second'], ['third']]);
+
+		monitor.close();
+	});
+
+	it('keeps each sample separate instead of merging them into the first delivered one', () => {
+		const monitor = createMonitor();
+
+		const created = [
+			createTaggedSample(monitor, 'first'),
+			createTaggedSample(monitor, 'second'),
+		];
+
+		const received: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+		// the replayed samples are the very objects created earlier, each still
+		// bounding its own time window
+		expect(received).toEqual(created);
+		expect(received[0].timestamp).toBeLessThanOrEqual(received[1].timestamp);
+
+		monitor.close();
+	});
+
+	it('does not replay a sample twice when a listener subscribes from inside its own handler', () => {
+		const monitor = createMonitor();
+
+		createTaggedSample(monitor, 'first');
+		createTaggedSample(monitor, 'second');
+
+		const received: string[][] = [];
+
+		monitor.on('sample-created', ({ sample }) => {
+			received.push(tagsOf(sample));
+			monitor.on('sample-created', () => { /* re-entrant subscription */ });
+		});
+
+		expect(received).toEqual([['first'], ['second']]);
+
+		monitor.close();
+	});
+});
+
+describe('the retention queue bound', () => {
+	it('keeps the newest samples and drops the oldest beyond the limit', () => {
+		const monitor = createMonitor({ maxRetainedSamplesBeforeFirstSubscriber: 3 });
+
+		for (const tag of ['first', 'second', 'third', 'fourth', 'fifth']) {
+			createTaggedSample(monitor, tag);
+		}
+
+		const received: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+		expect(received.map(tagsOf)).toEqual([['third'], ['fourth'], ['fifth']]);
+
+		monitor.close();
+	});
+
+	it('logs an error naming how many samples were dropped', () => {
+		const { logger, errors } = createRecordingLogger();
+		const monitor = createMonitor({ logger, maxRetainedSamplesBeforeFirstSubscriber: 2 });
+		const dropErrors = () => errors.filter(error => error.includes('Dropped'));
+
+		createTaggedSample(monitor, 'first');
+		createTaggedSample(monitor, 'second');
+
+		expect(dropErrors()).toHaveLength(0);
+
+		createTaggedSample(monitor, 'third');
+
+		expect(dropErrors()).toHaveLength(1);
+		expect(dropErrors()[0]).toContain('Dropped 1 sample(s)');
+
+		createTaggedSample(monitor, 'fourth');
+
+		// the count is cumulative, so the last message tells the whole story
+		expect(dropErrors()[1]).toContain('Dropped 2 sample(s)');
+
+		monitor.close();
+	});
+
+	it('discards every unconsumed sample when the limit is 0', () => {
+		const monitor = createMonitor({ maxRetainedSamplesBeforeFirstSubscriber: 0 });
+
+		createTaggedSample(monitor, 'first');
+
+		const received: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+		expect(received).toHaveLength(0);
+
+		monitor.close();
+	});
+});
+
+describe('closing without a subscriber', () => {
+	it('warns about the samples that were never delivered', () => {
+		const { logger, warnings } = createRecordingLogger();
+		const monitor = createMonitor({ logger });
+
+		createTaggedSample(monitor, 'first');
+		monitor.close();
+
+		expect(warnings.some(warning => warning.includes('never delivered'))).toBe(true);
+	});
+
+	it('still hands the retained samples to a consumer that subscribes after close', () => {
+		const monitor = createMonitor();
+
+		createTaggedSample(monitor, 'first');
+		monitor.close();
+
+		const received: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+		// close() creates a last sample of its own, which is retained too
+		expect(received.map(tagsOf)).toEqual([['first'], []]);
+	});
+});


### PR DESCRIPTION
## The bug

`createSample()` builds a sample, clears the four buffers it drained, and only then emits `'sample-created'`:

```js
const clientSample = { /* … */ clientEvents: this._clientEvents, clientMetaItems: this._clientMetaItems, /* … */ };
this._clientEvents = []; this._clientMetaItems = []; this._clientIssues = []; this._extensionStats = [];
return clientSample ? (this.emit('sample-created', { clientMonitor: this, sample: clientSample }), /* … */) : undefined;
```

Before any listener subscribes, that emit reaches nobody and nothing re-queues the sample. Everything reported between construction and the first subscriber is discarded — including the `USER_AGENT_DATA` the constructor itself collects via `Sources.fetchUserAgentData()`, so a consumer that subscribes after the first sampling tick never learns the browser it is running in.

`bufferingEventsForSamples` does not cover this. Per its own docstring it decides whether items are *accepted while sampling is off*:

```js
if (!this._samplingTick && !this.config.bufferingEventsForSamples) return;
```

With sampling on, that guard never trips: items are accepted, then discarded by the next `createSample()`.

## The fix

Hold a sample nobody can receive in a bounded queue, and replay it — in creation order — when the first `'sample-created'` listener subscribes. Each retained sample stays the one built for its own window, so a late consumer sees the sequence an early one would have, rather than one sample stamped when it happened to subscribe.

Three details worth a look:

- **The flush runs from the `on`/`once` overrides and again from `createSample()`.** `addListener` resolves to `EventEmitter.prototype.on` at prototype level and bypasses the subclass override, so a consumer subscribing that way would otherwise never trigger a replay.
- **The queue is swapped out before emitting**, so a listener that subscribes from inside its own handler re-enters and finds it empty. No re-entrancy flag needed.
- **Beyond the limit the oldest is dropped and an error names the running total.** The bound is sized so a session that ever attaches a consumer cannot reach it, so reaching it means data is being lost and should be loud. `maxRetainedSamplesBeforeFirstSubscriber: 0` restores the previous behaviour.

## Tests

`tests/SampleLossBeforeFirstSubscriber.spec.ts` states the contract: seven cases for what a late subscriber must receive, asserting *what is delivered* and never how many samples carry it. All seven fail on `master` — worth checking, since that is the regression guard:

```bash
git checkout master -- src && npx jest tests/SampleLossBeforeFirstSubscriber.spec.ts --forceExit; git checkout HEAD -- src
```

```
✕ reaches a consumer that subscribes afterwards
✕ includes client events, not only meta data
✕ includes the user agent data the constructor collects
✕ keeps the order it was reported in
✕ is delivered once, however many consumers subscribe
✕ reaches a consumer that subscribes through `once`
✕ reaches a consumer that subscribes through the `onsamplecreated` setter
✓ receives every sample once, in order, with nothing replayed

Tests: 7 failed, 1 passed, 8 total
```

The eighth passes on `master` and pins what the fix must not disturb. `tests/SampleRetention.spec.ts` adds what retention specifically guarantees: separate samples each bounding their own window, the queue bound, the overflow error, and behaviour on close.

`--forceExit` is needed because a failing assertion never reaches `monitor.close()`, so the collect timer keeps the process alive.

## Compatibility

No change for a consumer that subscribes immediately: the queue is always empty, one emit per sample, same order, same objects — asserted by the enabled case above.

**`createSample()` still returns the sample**, so the documented "Manual Sampling" flow is unaffected and no existing test needed changing.

That last point is worth dwelling on, because the obvious alternative fails it. I also implemented *deferral* — don't build a sample at all while nobody is subscribed, and let the buffers accumulate — and it passes all seven contract cases but costs two things this does not:

1. **It breaks the documented pull API.** README "Manual Sampling" calls `createSample()` with no subscriber and reads the return; under deferral that returns `undefined`. Eight existing tests failed, and keeping them green needed a no-op listener added to two spec helpers. Two of them did not fail but became *vacuous* — `undefined?.clientIssues ?? []` satisfies `toHaveLength(0)` — so they would have kept passing while asserting nothing.
2. **A sample's timestamp stops bounding its contents.** One merged sample arrives covering everything back to construction.

It also still needs its own cap and overflow signalling, so it is not the simpler option it looks like. Happy to push that branch too if you would like to see it.

## Not included

No `CHANGELOG.md` entry — that file looks like it is written when a release is cut. Say the word and I will add one.
