### PR TITLE
[DO NOT MERGE] fix: defer sampling until a sample-created consumer exists — alternative for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ const monitor = new ClientMonitor({
     addClientJointEventOnCreated: true, // Default: true
     addClientLeftEventOnClose: true, // Default: true
     bufferingEventsForSamples: false, // Default: false
+    maxBufferedSampleItems: 1000, // Default: 1000, per buffer
 
     // Detector configurations (all optional).
     //
@@ -1660,12 +1661,28 @@ const monitor = new ClientMonitor({
     bufferingEventsForSamples: true, // Required for manual sampling
 });
 
+// Required: no sample is created while nothing consumes them
+monitor.on("sample-created", ({ sample }) => console.log("Sample:", sample));
+
 // Create sample manually
 const sample = monitor.createSample();
 if (sample) {
     console.log("Manual sample:", sample);
 }
 ```
+
+`createSample()` returns `undefined` until a `sample-created` consumer has
+subscribed. Creating a sample drains the client events, meta items, issues and
+extension stats buffered since the previous one, so sampling before anything
+consumes the result would throw that data away — including the `USER_AGENT_DATA`
+the constructor collects. The monitor therefore keeps the buffers instead, and
+the first sample created once a consumer exists carries everything reported
+since construction. That first sample's `timestamp` marks when it was built, not
+the span it covers; each entry inside it carries its own `timestamp`.
+
+A monitor that never gets a consumer keeps at most `maxBufferedSampleItems`
+entries in each buffer (1000 by default), dropping the oldest and logging an
+error naming how many were lost.
 
 ### Sample Compression
 

--- a/src/ClientMonitor.ts
+++ b/src/ClientMonitor.ts
@@ -37,6 +37,13 @@ import { ClientEventPayloadProvider } from './sources/ClientEventPayloadProvider
 
 const MODULE_NAME = 'ClientMonitor';
 
+/**
+ * How often, at most, a full sample buffer reports the entries it dropped.
+ * Overflow happens once per added entry, so an unthrottled error per drop
+ * would itself become the flood it is warning about.
+ */
+const DROPPED_SAMPLE_ITEMS_LOG_COOLDOWN_MS = 10_000;
+
 export type ExtensionStatProvider = () => { type: string, payload?: ClientPayload } | Promise<{ type: string, payload?: ClientPayload }>;
 export class ClientMonitor<AppData extends Record<string, unknown> = Record<string, unknown>> extends EventEmitter<ClientMonitorEvents> {
     public static readonly samplingSchemaVersion = schemaVersion;
@@ -106,6 +113,12 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
     private _clientMetaItems: ClientSampleClientMetaData[] = [];
     private _clientIssues: ClientSampleClientIssue[] = [];
     private _extensionStats: ExtensionStat[] = [];
+    /** How many `createSample()` calls were skipped for want of a consumer. */
+    private _deferredSampleRequests = 0;
+    /** Latched by the first `'sample-created'` listener, never cleared. */
+    private _hadSampleConsumer = false;
+    /** Per buffer: entries dropped on overflow, and when that was last logged. */
+    private readonly _droppedSampleItems = new Map<string, { count: number, lastLoggedAt: number }>();
     public durationOfCollectingStatsInMs = 0;
     public readonly config: AppliedClientMonitorConfig<AppData>;
 
@@ -281,6 +294,7 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
                 iceRestartRecommendationCooldownInMs: 15000,
             }),
             bufferingEventsForSamples: monitorConfig.bufferingEventsForSamples ?? false,
+            maxBufferedSampleItems: Math.max(1, monitorConfig.maxBufferedSampleItems ?? 1000),
             sendResolvedIssuesToServer: monitorConfig.sendResolvedIssuesToServer ?? true,
             sendScoreReasonsToServer: monitorConfig.sendScoreReasonsToServer ?? true,
             sendIceTransportMetadataOnChangeOnly: monitorConfig.sendIceTransportMetadataOnChangeOnly ?? true,
@@ -396,18 +410,40 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
             this.createSample();
         }
 
+        // Sampling was deferred for this monitor's whole lifetime, so the
+        // buffers go with it. Nobody ever subscribed to receive them, but the
+        // silence is worth one line in the log.
+        if (!this._hadSampleConsumer && 0 < this._deferredSampleRequests) {
+            const buffered = this._clientEvents.length
+                + this._clientMetaItems.length
+                + this._clientIssues.length
+                + this._extensionStats.length;
+
+            this.logger.warn(
+                `[${MODULE_NAME}]:`,
+                `Closing without ever having a 'sample-created' consumer: ${this._deferredSampleRequests} sampling(s) were deferred and ${buffered} buffered entries are discarded.`,
+            );
+        }
+
         this.closed = true;
         this.emit('close');
     }
 
     public on<K extends keyof ClientMonitorEvents>(event: K, listener: (...args: ClientMonitorEvents[K]) => void): this {
         super.on(event, listener);
+        this._onListenerAdded(event);
 
         return this;
     }
 
+    /** `EventEmitter.addListener` is an alias of `on`, and must stay one here. */
+    public addListener<K extends keyof ClientMonitorEvents>(event: K, listener: (...args: ClientMonitorEvents[K]) => void): this {
+        return this.on(event, listener);
+    }
+
     public once<K extends keyof ClientMonitorEvents>(event: K, listener: (...args: ClientMonitorEvents[K]) => void): this {
         super.once(event, listener);
+        this._onListenerAdded(event);
 
         return this;
     }
@@ -517,6 +553,11 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
 
     public createSample(): ClientSample | undefined {
         if (this.closed) return;
+        if (this._shouldDeferSampling()) {
+            ++this._deferredSampleRequests;
+
+            return;
+        }
 
         const clientSample: ClientSample = {
             clientId: this.clientId,
@@ -548,8 +589,124 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
             sample: clientSample
         });
         this.lastSampledAt = timestamp;
+        this._reportDroppedSampleItems();
 
         return clientSample;
+    }
+
+    /**
+     * True while no `'sample-created'` consumer has ever subscribed.
+     *
+     * Creating a sample drains the four buffers into it, so a sample built
+     * before anyone listens throws away everything reported since the previous
+     * one — including the `USER_AGENT_DATA` the constructor itself collects.
+     * Rather than sample into the void, hold off entirely and let the buffers
+     * accumulate; the first sample created once a consumer exists carries
+     * everything since construction.
+     *
+     * The cost, and it is a real one: that first sample's `timestamp` no longer
+     * bounds its contents. The timestamp marks when the sample was built, while
+     * the events, meta items, issues and extension stats inside it reach all the
+     * way back to construction. Each entry carries its own `timestamp`, so a
+     * consumer that needs the time of an entry must read the entry's; the
+     * sample-level fields (score, peer connection stats) remain a snapshot of
+     * the moment the sample was built. Nothing describes the deferred period as
+     * a series of samples either: one sample arrives where an
+     * always-subscribed consumer would have seen several.
+     *
+     * The latch is deliberately one-way. It answers "has this monitor ever had
+     * a consumer", which is the window the loss happens in; an application that
+     * detaches its consumer later is back to the ordinary behaviour of samples
+     * being created and reaching nobody, rather than silently hoarding.
+     */
+    private _shouldDeferSampling(): boolean {
+        if (this._hadSampleConsumer) return false;
+        if (0 < this.listenerCount('sample-created')) {
+            this._hadSampleConsumer = true;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * The first `'sample-created'` consumer takes over the backlog: if sampling
+     * was asked for while nobody was listening, one sample is created here and
+     * now, synchronously, so a consumer that subscribes late does not wait a
+     * whole sampling period for data already sitting in the buffers.
+     *
+     * Nothing happens for a consumer that was there from the start — no
+     * sampling was deferred, so there is nothing to hand over.
+     */
+    private _onListenerAdded(event: keyof ClientMonitorEvents): void {
+        if (event !== 'sample-created') return;
+        if (this._hadSampleConsumer || this.closed) return;
+
+        this._hadSampleConsumer = true;
+
+        if (this._deferredSampleRequests < 1) return;
+
+        this._deferredSampleRequests = 0;
+        this.createSample();
+    }
+
+    /**
+     * Appends an entry to one of the four sample buffers, dropping the oldest
+     * entries of that buffer once it is full.
+     *
+     * The cap is per buffer rather than a single budget shared by the four,
+     * because they fill at wildly different rates: extension stats arrive on
+     * every collecting tick, meta items a handful per session. Under one shared
+     * budget the fastest producer would evict every other kind, starting with
+     * the oldest entry of all — the constructor's `USER_AGENT_DATA`, which is
+     * precisely what deferring sampling exists to preserve. Per buffer bounds
+     * memory just as tightly (four times the cap) and leaves each kind its own
+     * most recent entries.
+     */
+    private _pushSampleItem<T>(buffer: T[], item: T, bufferName: string): void {
+        buffer.push(item);
+
+        const cap = this.config.maxBufferedSampleItems;
+
+        if (buffer.length <= cap) return;
+
+        const dropped = buffer.splice(0, buffer.length - cap).length;
+        const state = this._droppedSampleItems.get(bufferName) ?? { count: 0, lastLoggedAt: 0 };
+
+        state.count += dropped;
+        this._droppedSampleItems.set(bufferName, state);
+
+        const now = Date.now();
+
+        if (state.lastLoggedAt !== 0 && now - state.lastLoggedAt < DROPPED_SAMPLE_ITEMS_LOG_COOLDOWN_MS) return;
+
+        state.lastLoggedAt = now;
+        this.logger.error(
+            `[${MODULE_NAME}]:`,
+            `The ${bufferName} buffer is full at ${cap} entries and dropped ${state.count} of the oldest so far. ` +
+            'Nothing is sampled until a `sample-created` consumer subscribes; subscribe one, or raise `maxBufferedSampleItems`.',
+        );
+    }
+
+    /**
+     * Names everything the caps dropped since the previous sample, on the
+     * sample that is missing it. The throttled overflow errors above report
+     * whatever the total stood at when they were allowed to speak; this one
+     * closes the account, so the totals are never left understated.
+     */
+    private _reportDroppedSampleItems(): void {
+        if (this._droppedSampleItems.size < 1) return;
+
+        const summary = [...this._droppedSampleItems.entries()]
+            .map(([bufferName, { count }]) => `${count} from ${bufferName}`)
+            .join(', ');
+
+        this._droppedSampleItems.clear();
+        this.logger.error(
+            `[${MODULE_NAME}]:`,
+            `This sample is incomplete: the buffer caps dropped ${summary} while it was waiting to be sampled.`,
+        );
     }
 
     public addPeerConnectionMonitor(peerConnectionMonitor: PeerConnectionMonitor): void {
@@ -601,11 +758,11 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
         const timestamp = event.timestamp ?? Date.now();
 
         // Schema 3.5.0 carries payloads as records — nothing to serialise.
-        this._clientEvents.push({
+        this._pushSampleItem(this._clientEvents, {
             ...event,
             payload: event.payload as ClientSampleClientEvent['payload'],
             timestamp,
-        });
+        }, 'clientEvents');
 
         this.emit('client-event', {
             ...event,
@@ -786,12 +943,12 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
         // is unconditional. Listeners always see the issue.
         if (!this._samplingTick && !this.config.bufferingEventsForSamples) return;
 
-        this._clientIssues.push({
+        this._pushSampleItem(this._clientIssues, {
             type,
             key,
             payload: payload as ClientSampleClientIssue['payload'],
             timestamp,
-        });
+        }, 'clientIssues');
     }
 
     public addMetaData(metaData: PartialBy<ClientMetaData, 'timestamp'>): void {
@@ -800,11 +957,11 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
 
         const timestamp = metaData.timestamp ?? Date.now();
 
-        this._clientMetaItems.push({
+        this._pushSampleItem(this._clientMetaItems, {
             type: metaData.type,
             payload: metaData.payload as ClientSampleClientMetaData['payload'],
             timestamp,
-        });
+        }, 'clientMetaItems');
 
         this.emit('meta', {
             ...metaData,
@@ -818,10 +975,10 @@ export class ClientMonitor<AppData extends Record<string, unknown> = Record<stri
         if (!this._samplingTick && !this.config.bufferingEventsForSamples) return;
 
         // Schema 3.5.0 carries payloads as records — nothing to serialise.
-        this._extensionStats.push({
+        this._pushSampleItem(this._extensionStats, {
             type: stats.type,
             payload: stats.payload as ExtensionStat['payload'],
-        });
+        }, 'extensionStats');
 
         this.emit('extension-stats', {
             ...stats,

--- a/src/ClientMonitorConfig.ts
+++ b/src/ClientMonitorConfig.ts
@@ -802,6 +802,20 @@ export type AppliedClientMonitorConfig<AppData extends Record<string, unknown> =
     sendIceTransportMetadataOnChangeOnly?: boolean;
 
     /**
+     * The largest number of entries each of the four sample buffers (client
+     * events, meta items, issues, extension stats) keeps while it waits to be
+     * sampled. Once a buffer is full its oldest entries are dropped and an
+     * error is logged naming how many were lost.
+     *
+     * The cap matters because no sample is created before the first
+     * `'sample-created'` consumer subscribes, so an application that never
+     * subscribes would otherwise buffer for the lifetime of the page.
+     *
+     * DEFAULT: 1000 (per buffer, so at most 4000 entries in total)
+     */
+    maxBufferedSampleItems: number;
+
+    /**
      * Additional metadata to be included in the client monitor.
      *
      * OPTIONAL

--- a/tests/ClientMonitorIssueLifecycle.spec.ts
+++ b/tests/ClientMonitorIssueLifecycle.spec.ts
@@ -3,13 +3,20 @@ import { ClientMonitor } from "../src/ClientMonitor";
 const silentLogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 function createMonitor(config: Record<string, unknown> = {}) {
-	return new ClientMonitor({
+	const monitor = new ClientMonitor({
 		logger: silentLogger,
 		integrateNavigatorMediaDevices: false,
 		addClientJointEventOnCreated: false,
 		addClientLeftEventOnClose: false,
 		...config,
 	});
+
+	// Sampling is deferred until a `sample-created` consumer exists, so a monitor
+	// nobody subscribes to returns nothing from `createSample()`. These tests read
+	// the returned sample, so they need a consumer even though they ignore it.
+	monitor.on('sample-created', () => { /* the consumer these tests sample for */ });
+
+	return monitor;
 }
 
 describe('ClientMonitor issue lifecycle in samples', () => {

--- a/tests/DeferredSampling.spec.ts
+++ b/tests/DeferredSampling.spec.ts
@@ -1,0 +1,294 @@
+import { ClientMonitor } from "../src/ClientMonitor";
+import { ClientSample } from "../src/schema/ClientSample";
+import { Logger } from "../src/utils/logger";
+
+/**
+ * Sampling is deferred while no `'sample-created'` consumer exists: rather than
+ * build a sample that reaches nobody and drains the four buffers into it, the
+ * monitor creates nothing and lets the buffers accumulate. The first sample
+ * created once a consumer subscribes carries everything since construction.
+ *
+ * `SampleLossBeforeFirstSubscriber.spec.ts` states what a late consumer must
+ * receive, without saying how. This file covers what is specific to deferring:
+ * that nothing is produced meanwhile, that the handover happens the moment a
+ * consumer arrives, that the buffers are capped, and that a consumer present
+ * from the start sees no difference at all.
+ */
+
+type LoggedLine = unknown[];
+
+function createRecordingLogger(lines: LoggedLine[], level: 'error' | 'warn' = 'error'): Logger {
+	const record = (...args: unknown[]) => lines.push(args);
+
+	return {
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: level === 'warn' ? record : () => {},
+		error: level === 'error' ? record : () => {},
+	};
+}
+
+/**
+ * Only the lines this file is about. A monitor constructed under a Node user
+ * agent also logs a failure to parse it, which is none of our business here.
+ */
+function linesMatching(lines: LoggedLine[], needle: string) {
+	return lines.map(line => line.join(' ')).filter(line => line.includes(needle));
+}
+
+const silentLogger: Logger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createMonitor(config: Record<string, unknown> = {}) {
+	return new ClientMonitor({
+		logger: silentLogger,
+		integrateNavigatorMediaDevices: false,
+		addClientJointEventOnCreated: false,
+		addClientLeftEventOnClose: false,
+		watchTabVisibility: false,
+		...config,
+	});
+}
+
+function collect(monitor: ClientMonitor) {
+	const received: ClientSample[] = [];
+
+	monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+	return received;
+}
+
+function metaTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientMetaItems ?? []).map(item => item.type));
+}
+
+describe('sampling deferred until the first consumer', () => {
+	it('creates no sample at all while nobody is subscribed', () => {
+		const monitor = createMonitor();
+
+		monitor.addEvent({ type: 'EARLY_EVENT' });
+
+		// nothing to hand a sample to, so none is built
+		expect(monitor.createSample()).toBeUndefined();
+		expect(monitor.createSample()).toBeUndefined();
+		// ...and none was timestamped either
+		expect(monitor.lastSampledAt).toBe(0);
+
+		monitor.close();
+	});
+
+	it('hands the whole backlog to the first consumer the moment it subscribes', () => {
+		const monitor = createMonitor();
+
+		monitor.addEvent({ type: 'EARLY_EVENT' });
+		monitor.addMetaData({ type: 'EARLY_META' });
+		monitor.addIssue({ type: 'early-issue' });
+		monitor.addExtensionStats({ type: 'EARLY_EXT' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		// subscribing is itself the trigger: no further sampling was needed
+		expect(received).toHaveLength(1);
+
+		const sample = received[0];
+
+		expect((sample?.clientEvents ?? []).map(event => event.type)).toContain('EARLY_EVENT');
+		expect((sample?.clientMetaItems ?? []).map(item => item.type)).toEqual(
+			expect.arrayContaining(['USER_AGENT_DATA', 'EARLY_META']),
+		);
+		expect((sample?.clientIssues ?? []).map(issue => issue.type)).toContain('early-issue');
+		expect((sample?.extensionStats ?? []).map(stat => stat.type)).toContain('EARLY_EXT');
+
+		monitor.close();
+	});
+
+	it('hands the backlog over through `addListener` as well as `on`', () => {
+		const monitor = createMonitor();
+
+		monitor.addMetaData({ type: 'EARLY_META' });
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		// `addListener` is an alias of `on` and must not bypass the handover
+		monitor.addListener('sample-created', ({ sample }) => received.push(sample));
+
+		expect(metaTypes(received)).toContain('EARLY_META');
+
+		monitor.close();
+	});
+
+	it('produces nothing on subscribe when no sampling was ever asked for', () => {
+		const monitor = createMonitor();
+
+		monitor.addMetaData({ type: 'EARLY_META' });
+
+		// no `createSample()` call was deferred, so there is nothing to hand over
+		// and the buffers wait for the next ordinary sampling
+		const received = collect(monitor);
+
+		expect(received).toHaveLength(0);
+
+		monitor.createSample();
+
+		expect(metaTypes(received)).toContain('EARLY_META');
+
+		monitor.close();
+	});
+
+	it('leaves a consumer that was there from the start entirely unaffected', () => {
+		const monitor = createMonitor();
+		const received = collect(monitor);
+
+		monitor.addMetaData({ type: 'FIRST' });
+		monitor.createSample();
+		monitor.addMetaData({ type: 'SECOND' });
+		monitor.createSample();
+
+		// one sample per call, each draining only what was reported since the last
+		expect(received).toHaveLength(2);
+		expect((received[0]?.clientMetaItems ?? []).map(item => item.type)).toEqual(['USER_AGENT_DATA', 'FIRST']);
+		expect((received[1]?.clientMetaItems ?? []).map(item => item.type)).toEqual(['SECOND']);
+		expect(monitor.lastSampledAt).toBeGreaterThan(0);
+
+		monitor.close();
+	});
+
+	it('goes back to ordinary sampling once a consumer has been seen, even if it detaches', () => {
+		const monitor = createMonitor();
+		const received: ClientSample[] = [];
+		const listener = ({ sample }: { sample: ClientSample }) => received.push(sample);
+
+		monitor.on('sample-created', listener);
+		monitor.off('sample-created', listener);
+		monitor.addMetaData({ type: 'AFTER_DETACH' });
+
+		// the latch is one-way: a monitor that once had a consumer is back to the
+		// plain behaviour of creating samples, rather than hoarding again
+		expect(monitor.createSample()).toBeDefined();
+		expect(received).toHaveLength(0);
+
+		monitor.close();
+	});
+
+	it('delivers the backlog to a consumer that subscribes between samplings, in order', () => {
+		const monitor = createMonitor();
+
+		monitor.addMetaData({ type: 'BEFORE_ONE' });
+		monitor.createSample();
+		monitor.addMetaData({ type: 'BEFORE_TWO' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		monitor.addMetaData({ type: 'AFTER' });
+		monitor.createSample();
+
+		// the two deferred samplings collapse into the single handover sample,
+		// the third is an ordinary one — nothing is lost or reordered
+		expect(received).toHaveLength(2);
+		expect(metaTypes(received)).toEqual(['USER_AGENT_DATA', 'BEFORE_ONE', 'BEFORE_TWO', 'AFTER']);
+
+		monitor.close();
+	});
+});
+
+describe('the buffer cap that bounds a never-subscribed monitor', () => {
+	it('drops the oldest entries and logs how many were lost', () => {
+		const errors: LoggedLine[] = [];
+		const monitor = createMonitor({ logger: createRecordingLogger(errors), maxBufferedSampleItems: 3 });
+
+		// the constructor's USER_AGENT_DATA already occupies one slot
+		for (const type of ['M1', 'M2', 'M3', 'M4']) monitor.addMetaData({ type });
+
+		const received = collect(monitor);
+
+		monitor.createSample();
+
+		// oldest first: USER_AGENT_DATA and M1 are gone, the cap's worth remains
+		expect(metaTypes(received)).toEqual(['M2', 'M3', 'M4']);
+
+		// the first overflow is reported as it happens...
+		const overflows = linesMatching(errors, 'buffer is full');
+
+		expect(overflows).toHaveLength(1);
+		expect(overflows[0]).toContain('clientMetaItems');
+
+		// ...and the sample that is missing them names the full count
+		const summary = linesMatching(errors, 'This sample is incomplete');
+
+		expect(summary).toHaveLength(1);
+		expect(summary[0]).toContain('dropped 2 from clientMetaItems');
+
+		monitor.close();
+	});
+
+	it('caps each buffer on its own, so a flood of one kind cannot evict another', () => {
+		const monitor = createMonitor({ maxBufferedSampleItems: 3 });
+
+		for (let i = 0; i < 50; ++i) monitor.addExtensionStats({ type: `EXT_${i}` });
+
+		const received = collect(monitor);
+
+		monitor.createSample();
+
+		// the extension stats overflowed, but the single meta item the constructor
+		// collected — the whole point of deferring — is untouched
+		expect(metaTypes(received)).toEqual(['USER_AGENT_DATA']);
+		expect((received[0]?.extensionStats ?? []).map(stat => stat.type)).toEqual(['EXT_47', 'EXT_48', 'EXT_49']);
+
+		monitor.close();
+	});
+
+	it('reports the running total once per buffer rather than once per dropped entry', () => {
+		const errors: LoggedLine[] = [];
+		const monitor = createMonitor({ logger: createRecordingLogger(errors), maxBufferedSampleItems: 2 });
+
+		for (let i = 0; i < 100; ++i) monitor.addEvent({ type: `E_${i}` });
+
+		// one error for the first overflow; the other 97 are held back by the
+		// cooldown, so the log cannot become the flood it reports
+		const overflows = linesMatching(errors, 'buffer is full');
+
+		expect(overflows).toHaveLength(1);
+		expect(overflows[0]).toContain('clientEvents');
+
+		monitor.close();
+	});
+});
+
+describe('closing a monitor that never had a consumer', () => {
+	it('says so, naming what is discarded', () => {
+		const warnings: LoggedLine[] = [];
+		const monitor = createMonitor({ logger: createRecordingLogger(warnings, 'warn'), maxBufferedSampleItems: 10 });
+
+		monitor.addMetaData({ type: 'NEVER_DELIVERED' });
+		monitor.createSample();
+		// `close()` samples once more, and that sampling is deferred too
+		monitor.close();
+
+		const discarded = linesMatching(warnings, "without ever having a 'sample-created' consumer");
+
+		expect(discarded).toHaveLength(1);
+		expect(discarded[0]).toContain('2 sampling(s) were deferred');
+		// USER_AGENT_DATA and NEVER_DELIVERED, neither of which reached anyone
+		expect(discarded[0]).toContain('2 buffered entries are discarded');
+	});
+
+	it('stays quiet when the backlog was handed over', () => {
+		const warnings: LoggedLine[] = [];
+		const monitor = createMonitor({ logger: createRecordingLogger(warnings, 'warn') });
+
+		monitor.addMetaData({ type: 'DELIVERED' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(received).toHaveLength(1);
+
+		monitor.close();
+
+		expect(linesMatching(warnings, "without ever having a 'sample-created' consumer")).toHaveLength(0);
+	});
+});

--- a/tests/SampleLossBeforeFirstSubscriber.spec.ts
+++ b/tests/SampleLossBeforeFirstSubscriber.spec.ts
@@ -1,0 +1,189 @@
+import { ClientMonitor } from "../src/ClientMonitor";
+import { ClientSample } from "../src/schema/ClientSample";
+import { Logger } from "../src/utils/logger";
+
+/**
+ * `createSample()` builds a sample, clears the four buffers it drained, and only
+ * then emits `'sample-created'`. Before any listener subscribes that emit reaches
+ * nobody, and nothing re-queues the sample — so everything reported between
+ * construction and the first subscriber is lost.
+ *
+ * The disabled cases below describe what a consumer that subscribes late should
+ * receive. They assert *what is delivered*, never how many samples carry it, so
+ * they hold for any fix that stops discarding the data. A fix enables them.
+ *
+ * The one enabled case is the opposite: it passes today and locks in the
+ * behaviour a fix must not disturb.
+ */
+
+const silentLogger: Logger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createMonitor(config: Record<string, unknown> = {}) {
+	return new ClientMonitor({
+		logger: silentLogger,
+		integrateNavigatorMediaDevices: false,
+		addClientJointEventOnCreated: false,
+		addClientLeftEventOnClose: false,
+		watchTabVisibility: false,
+		...config,
+	});
+}
+
+const TAG_PREFIX = 'test-tag:';
+
+function addTag(monitor: ClientMonitor, tag: string) {
+	monitor.addMetaData({ type: `${TAG_PREFIX}${tag}` });
+}
+
+/** Everything tagged that reached the consumer, in delivery order. */
+function deliveredTags(samples: ClientSample[]) {
+	return samples.flatMap(sample =>
+		(sample.clientMetaItems ?? [])
+			.filter(item => item.type.startsWith(TAG_PREFIX))
+			.map(item => item.type.slice(TAG_PREFIX.length))
+	);
+}
+
+function deliveredMetaTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientMetaItems ?? []).map(item => item.type));
+}
+
+function deliveredEventTypes(samples: ClientSample[]) {
+	return samples.flatMap(sample => (sample.clientEvents ?? []).map(event => event.type));
+}
+
+function collect(monitor: ClientMonitor) {
+	const received: ClientSample[] = [];
+
+	monitor.on('sample-created', ({ sample }) => received.push(sample));
+
+	return received;
+}
+
+describe('data reported before the first `sample-created` subscriber', () => {
+	xit('reaches a consumer that subscribes afterwards', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	xit('includes client events, not only meta data', () => {
+		const monitor = createMonitor();
+
+		monitor.addEvent({ type: 'EARLY_EVENT' });
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredEventTypes(received)).toContain('EARLY_EVENT');
+
+		monitor.close();
+	});
+
+	xit('includes the user agent data the constructor collects', () => {
+		// The clearest case: no caller is involved at all. The constructor calls
+		// `fetchUserAgentData()`, so a consumer subscribing after the first
+		// sampling tick never learns the browser it is running in.
+		const monitor = createMonitor();
+
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		expect(deliveredMetaTypes(received)).toContain('USER_AGENT_DATA');
+
+		monitor.close();
+	});
+
+	xit('keeps the order it was reported in', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		const received = collect(monitor);
+
+		addTag(monitor, 'third');
+		monitor.createSample();
+
+		expect(deliveredTags(received)).toEqual(['first', 'second', 'third']);
+
+		monitor.close();
+	});
+
+	xit('is delivered once, however many consumers subscribe', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received = collect(monitor);
+		const second: ClientSample[] = [];
+
+		monitor.on('sample-created', ({ sample }) => second.push(sample));
+
+		expect(deliveredTags(received)).toEqual(['first']);
+		expect(deliveredTags(second)).toEqual([]);
+
+		monitor.close();
+	});
+
+	xit('reaches a consumer that subscribes through `once`', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.once('sample-created', ({ sample }) => received.push(sample));
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+
+	xit('reaches a consumer that subscribes through the `onsamplecreated` setter', () => {
+		const monitor = createMonitor();
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+
+		const received: ClientSample[] = [];
+
+		monitor.onsamplecreated = ({ sample }) => received.push(sample);
+
+		expect(deliveredTags(received)).toContain('first');
+
+		monitor.close();
+	});
+});
+
+describe('a consumer subscribed from the start', () => {
+	// Enabled: this passes today, and a fix for the cases above must not change
+	// it. Nothing is withheld, replayed, or reordered for a consumer that was
+	// always there.
+	it('receives every sample once, in order, with nothing replayed', () => {
+		const monitor = createMonitor();
+		const received = collect(monitor);
+
+		addTag(monitor, 'first');
+		monitor.createSample();
+		addTag(monitor, 'second');
+		monitor.createSample();
+
+		expect(received).toHaveLength(2);
+		expect(deliveredTags(received)).toEqual(['first', 'second']);
+
+		monitor.close();
+	});
+});

--- a/tests/SampleLossBeforeFirstSubscriber.spec.ts
+++ b/tests/SampleLossBeforeFirstSubscriber.spec.ts
@@ -61,7 +61,7 @@ function collect(monitor: ClientMonitor) {
 }
 
 describe('data reported before the first `sample-created` subscriber', () => {
-	xit('reaches a consumer that subscribes afterwards', () => {
+	it('reaches a consumer that subscribes afterwards', () => {
 		const monitor = createMonitor();
 
 		addTag(monitor, 'first');
@@ -74,7 +74,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('includes client events, not only meta data', () => {
+	it('includes client events, not only meta data', () => {
 		const monitor = createMonitor();
 
 		monitor.addEvent({ type: 'EARLY_EVENT' });
@@ -87,7 +87,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('includes the user agent data the constructor collects', () => {
+	it('includes the user agent data the constructor collects', () => {
 		// The clearest case: no caller is involved at all. The constructor calls
 		// `fetchUserAgentData()`, so a consumer subscribing after the first
 		// sampling tick never learns the browser it is running in.
@@ -102,7 +102,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('keeps the order it was reported in', () => {
+	it('keeps the order it was reported in', () => {
 		const monitor = createMonitor();
 
 		addTag(monitor, 'first');
@@ -120,7 +120,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('is delivered once, however many consumers subscribe', () => {
+	it('is delivered once, however many consumers subscribe', () => {
 		const monitor = createMonitor();
 
 		addTag(monitor, 'first');
@@ -137,7 +137,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('reaches a consumer that subscribes through `once`', () => {
+	it('reaches a consumer that subscribes through `once`', () => {
 		const monitor = createMonitor();
 
 		addTag(monitor, 'first');
@@ -152,7 +152,7 @@ describe('data reported before the first `sample-created` subscriber', () => {
 		monitor.close();
 	});
 
-	xit('reaches a consumer that subscribes through the `onsamplecreated` setter', () => {
+	it('reaches a consumer that subscribes through the `onsamplecreated` setter', () => {
 		const monitor = createMonitor();
 
 		addTag(monitor, 'first');

--- a/tests/ScoreReasonsSampling.spec.ts
+++ b/tests/ScoreReasonsSampling.spec.ts
@@ -6,13 +6,20 @@ import { InboundTrackMonitor } from "../src/monitors/InboundTrackMonitor";
 const silentLogger = { trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
 
 function createMonitor(config: Record<string, unknown> = {}) {
-	return new ClientMonitor({
+	const monitor = new ClientMonitor({
 		logger: silentLogger,
 		integrateNavigatorMediaDevices: false,
 		addClientJointEventOnCreated: false,
 		addClientLeftEventOnClose: false,
 		...config,
 	});
+
+	// Sampling is deferred until a `sample-created` consumer exists, so a monitor
+	// nobody subscribes to returns nothing from `createSample()`. These tests read
+	// the returned sample, so they need a consumer even though they ignore it.
+	monitor.on('sample-created', () => { /* the consumer these tests sample for */ });
+
+	return monitor;
 }
 
 function addPcWithReasons(monitor: ClientMonitor) {


### PR DESCRIPTION
> ### DO NOT MERGE
> Opened only to show, in code, why this alternative is not viable. **#64 is the proposed fix.**

> **Note on reviewing:** built on #63, so the first commit is that PR's tests. Only the second commit is new here.

The other obvious way to fix #63: don't create a sample at all while nobody is subscribed, and let the buffers accumulate. It works — all seven cases from #63 pass — but it costs two things #64 does not.

## 1. It breaks the documented pull API

The README's "Manual Sampling" section shows this, with no subscriber:

```javascript
const sample = monitor.createSample();
if (sample) {
    console.log("Manual sample:", sample);
}
```

Under deferral that returns `undefined`. There is no way around it: the parent tests require that a `createSample()` with no subscriber must not drain the buffers, and the documented flow requires that same call to return the data.

Eight existing tests fail as a result. Keeping them green needed a no-op `sample-created` listener added to two spec helpers — visible in this diff.

Worse: two of those tests did not fail, they became **vacuous**. `undefined?.clientIssues ?? []` satisfies `toHaveLength(0)`, so they would have kept passing while asserting nothing.

## 2. A sample's timestamp stops bounding its contents

One merged sample arrives covering everything back to construction, where an always-subscribed consumer would have seen several, each bounding its own window. Entries still carry their own timestamps, but the sample's does not describe the sample.

## It is also not simpler

It still needs its own cap and overflow signalling, since the buffers would otherwise grow without limit. This branch caps per buffer rather than in total, because the four fill at very different rates and one shared budget would let the fastest producer evict the constructor's `USER_AGENT_DATA` — the very thing the fix exists to preserve.
